### PR TITLE
Fix(docs/installion): typo in Architectures

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -29,7 +29,7 @@ curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
 
 ### Supported Architectures
 
-- AMD64 
+- AMD86 
 - ARM64
 
 ### Minimum Required Server


### PR DESCRIPTION
Mirror typo in the Supported Architectures