### PR TITLE
Fix monospace formatting in Installation Step

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -151,7 +151,7 @@ The script will do the following on your operating system.
     </Tip>
   </Step>
     <Step title="Setup Configuration Files">
-    Copy the `docker-compose.yml`, `docker-compose.prod.yml`, `.e`nv.production` & `upgrade.sh` files from Coolify's CDN to `/data/coolify/source`.
+    Copy the `docker-compose.yml`, `docker-compose.prod.yml`, `.env.production` & `upgrade.sh` files from Coolify's CDN to `/data/coolify/source`.
 
     ```bash
     curl -fsSL https://cdn.coollabs.io/coolify/docker-compose.yml -o /data/coolify/source/docker-compose.yml


### PR DESCRIPTION
## What

- removes extra backtick in installation instructions

## Why

It was messing with the doc formatting. See screenshot:

![Screenshot 2024-04-18 at 8 49 10 AM](https://github.com/coollabsio/documentation-coolify/assets/5693033/b339faad-5ad6-44da-9e4f-3de0d874de0b)
