### PR TITLE
fix missing character in services introduction

### DIFF
--- a/resources/services/index.mdx
+++ b/resources/services/index.mdx
@@ -14,7 +14,7 @@ All services are open source and self-hostable.
 - [Authentik](./authentik) - An open-source Identity Provider, focused on flexibility and versatility.
 - [Baby Buddy](./babybuddy) - It helps parents track their baby's daily activities, growth, and health with ease.
 - [Budge](./budge) - A budgeting personal finance app.
-- [Change Detection](./changedetection) - ebsite change detection monitor and notifications.
+- [Change Detection](./changedetection) - Website change detection monitor and notifications.
 - [ClassicPress](./classicpress) - A business-focused CMS with a strong community.
 - [Code Server](./code-server) - Run VS Code on any machine anywhere and access it in the browser.
 - [Dashboard](./dashboard) - A simple dashboard for your server.


### PR DESCRIPTION
found a missing character in services introduction for the description of change detection

before:
![2024-04-28 01_43_27-What kind of one-click services could you host with Coolify](https://github.com/coollabsio/documentation-coolify/assets/14111588/16e2977f-acb0-43a7-90f5-5b6555c63fc2)

after:
![2024-04-28 01_43_40-What kind of one-click services could you host with Coolify](https://github.com/coollabsio/documentation-coolify/assets/14111588/f8fc3c14-74ec-4543-92c4-a370e21cb056)
