### PR TITLE
add coolify-proxy to uninstall.mdx

### DIFF
--- a/uninstall.mdx
+++ b/uninstall.mdx
@@ -11,8 +11,8 @@ To uninstall the self-hosted version of Coolify from your server, follow these s
    Use the following command to stop the Coolify containers with a timeout of 0, ensuring they stop immediately, and then remove them:
 
    ```bash
-   sudo docker stop -t 0 coolify coolify-realtime coolify-db coolify-redis
-   sudo docker rm coolify coolify-realtime coolify-db coolify-redis
+   sudo docker stop -t 0 coolify coolify-realtime coolify-db coolify-redis coolify-proxy
+   sudo docker rm coolify coolify-realtime coolify-db coolify-redis coolify-proxy
    ```
 
 2. **Remove Docker Volumes:**
@@ -49,6 +49,7 @@ To uninstall the self-hosted version of Coolify from your server, follow these s
    sudo docker rmi quay.io/soketi/soketi:1.6-16-alpine
    sudo docker rmi postgres:15-alpine
    sudo docker rmi redis:alpine
+   sudo docker rmi traefik:v2.10
    ```
 
 After completing these steps, Coolify will be uninstalled from your server.


### PR DESCRIPTION
I tried to uninstall coolify from my system and when removing the docker network it prompted me that there was still as service running in that network. The cause was coolify-proxy not being removed in the previous steps.