### PR TITLE
Fix typo in installation.mdx

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -17,7 +17,10 @@ You can use our [referral link](https://coolify.io/hetzner). It will helps us to
   TLDR for installation: ```bash curl -fsSL
   https://cdn.coollabs.io/coolify/install.sh | bash ```
 </Info>
-## Requirements ### Supported Operating Systems
+
+## Requirements 
+
+### Supported Operating Systems
 
 - Debian based Linux distributions (Debian, Ubuntu, etc.)
 - Redhat based Linux distributions (CentOS, Fedora, Redhat, AlmaLinux, Rocky etc.)


### PR DESCRIPTION
Fixes a little typo in the [installation documentation page](https://coolify.io/docs/installation#requirements-supported-operating-systems):

<img width="594" alt="image" src="https://github.com/coollabsio/documentation-coolify/assets/72663983/007a3032-65fa-47e3-b747-5c398f799878">
