### PR TITLE
Minor typo repair

### DIFF
--- a/knowledge-base/drain-logs.mdx
+++ b/knowledge-base/drain-logs.mdx
@@ -10,7 +10,7 @@ We will support more services in the future, like Signoz, HyperDX, etc.
 
 ## How to enable?
 
-Go to your `Server` where you want to enable the `Drain Logs` and click on the `Drain Logs` tab.
+Go to your `Server` where you want to enable the `Drain Logs` and click on the `Log Drains` tab.
 
 ## Axiom
 


### PR DESCRIPTION
UI tab is "log drains" not "drain logs"