### PR TITLE
fix: properly format referral link to hetzner

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -16,11 +16,9 @@ Coolify is an all-in one PaaS that helps you to self-host your own applications,
   </Card>
   <Card title="Any Server" icon="server">
     You can deploy your resources to any server, including your own servers,
-    VPS, Raspberry Pi, EC2, DigitalOcean, Linode, Hetzner{" "}
-    <a class="underline" href="https://coolify.io/hetzner" target="_blank">
-      (referral link)
-    </a>
-    , and more. All you need is an SSH connection.
+    VPS, Raspberry Pi, EC2, DigitalOcean, Linode, Hetzner
+    (<a class="underline" href="https://coolify.io/hetzner" target="_blank">referral link</a>),
+    and more. All you need is an SSH connection.
   </Card>
   <Card title="Any Use Case" icon="screwdriver-wrench">
     You can deploy your resources to a single server, multiple servers, or


### PR DESCRIPTION
Previously the referral link would be rendered as:

```
Linode, Hetzner
(referral link)
, and more. All you need is an SSH
```

with `(referral link)` as the content in the anchor tag. Now it is rendered as:

```
Linode, Hetzner (referral link), and
more. All you need is an SSH
```

with `referral link` as the content in the anchor tag.

- No more line breaks before and after the link, only spaces
- The parentheses is no longer a part of the link