### PR TITLE
fix: correct typo in installation

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -46,7 +46,7 @@ You can use our [referral link](https://coolify.io/hetzner). It will helps us to
 
 Choosing your server resources depends on your usage. If you are planning to run a lot of things, you should consider buying a server with more resources.
 
-Hosting `Supabase`, `Appwrite` or `Posthog` are requires more resources than hosting a static site (waay more).
+Hosting `Supabase`, `Appwrite` or `Posthog` requires more resources than hosting a static site (waay more).
 
 <Tip>
 


### PR DESCRIPTION
Fix typo from **are requires** to **requires**