### PR TITLE
added missing tls attribute to traefik dashboard access

### DIFF
--- a/knowledge-base/traefik/dashboard.mdx
+++ b/knowledge-base/traefik/dashboard.mdx
@@ -23,6 +23,8 @@ http:
     dashboard:
       rule: Host(`<DOMAIN_FOR_TRAEFIK>`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
       service: api@internal
+      tls:
+        certResolver: letsencrypt
       middlewares:
         - auth
   middlewares:


### PR DESCRIPTION
cant reach traefik dashboard without it

as previous discussed at Discord topic [here](https://discord.com/channels/459365938081431553/1257518474159198288)