### PR TITLE
Fixes a typo on the Ruby on Rails documentation

### DIFF
--- a/resources/applications/rails.mdx
+++ b/resources/applications/rails.mdx
@@ -4,7 +4,7 @@ title: Ruby on Rails
 description: "A guide on how to deploy Ruby on Rails apps with Coolify"
 ---
 
-Ruby on Rails is a web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
+Ruby on Rails is a web-application framework that includes everything needed to create database-backend web applications according to the Model-View-Controller (MVC) pattern.
 
 ## Requirements
 


### PR DESCRIPTION
Added "n" to the spelling of database-backend on the Ruby on Rails documentation