### PR TITLE
Fix actual broken self-hosted docs link

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -64,4 +64,4 @@ You get all the features in the self-hosted version, but you need to take care o
 - <strong>Open Source.</strong> You can see the source code and contribute to it,
   if you want. You can shape the future of the software.
 
-<a href="/installation">Let's get started!</a>
+<a href="https://coolify.io/docs/installation">Let's get started!</a>


### PR DESCRIPTION
The "Let's get started" link below Self-hosted on [/docs/quickstart ](https://coolify.io/docs/quickstart) links to https://coolify.io/installation which defaults to the homepage

This PR edits the right link. Mistakenly edited the wrong link in https://github.com/coollabsio/documentation-coolify/pull/56