### PR TITLE
Update self-hosted "Let's get started!" link in quickstart.mdx

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -64,4 +64,4 @@ You get all the features in the self-hosted version, but you need to take care o
 - <strong>Open Source.</strong> You can see the source code and contribute to it,
   if you want. You can shape the future of the software.
 
-<a href="/installation">Let's get started!</a>
+<a href="/docs/installation">Let's get started!</a>


### PR DESCRIPTION
/installation -> /docs/installation
Currently the redirect navigates to /installation and just shows the homepage.