### PR TITLE
Fix SSHD typo to SSH in OpenSSH setup

### DIFF
--- a/docs/knowledge-base/server/openssh.md
+++ b/docs/knowledge-base/server/openssh.md
@@ -36,12 +36,12 @@ These settings need to be configured manually before running the Coolify install
 
 SystemD:
   ```bash
-  systemctl restart sshd
+  systemctl restart ssh
   ```
 
 OpenRC:
   ```bash
-  rc-service sshd restart
+  rc-service ssh restart
   ```
 
 


### PR DESCRIPTION
# Fix SSH service restart commands

This PR corrects the SSH service restart commands in the OpenSSH documentation. 

The current documentation incorrectly instructs users to restart the SSH service using `systemctl restart sshd` and `rc-service sshd restart`. However, on many Linux distributions (particularly Debian-based ones), the service is named `ssh` rather than `sshd`.

When users try to execute the commands as written in the current documentation, they may encounter errors like "Failed to restart sshd.service: Unit sshd.service not found" in some environments.

This change ensures the documentation works correctly across more Linux distributions by updating the commands to use `ssh` instead of `sshd`.