### PR TITLE
Fixed Typo in sponsorship as spotted by cherrydub

### DIFF
--- a/docs/get-started/sponsors.md
+++ b/docs/get-started/sponsors.md
@@ -278,7 +278,7 @@ const sponsors = [
   },
   {
     avatar: '../images/team/coollabs-logo-smaller.webp',
-    name: 'You Company?',
+    name: 'Your Company?',
     title: 'Will Your Company Be Next?'
   }
 ]


### PR DESCRIPTION
I was useful. 🌮 Thanks for pointing that out cherrydub

Changes a typo inside sponsors section, "You" -> "Your"