### PR TITLE
comment out httpchallenge in traefik config example

### DIFF
--- a/docs/knowledge-base/proxy/traefik/wildcard-certs.md
+++ b/docs/knowledge-base/proxy/traefik/wildcard-certs.md
@@ -62,8 +62,9 @@ services:
       - '--providers.docker.exposedbydefault=false'
       - '--providers.file.directory=/traefik/dynamic/'
       - '--providers.file.watch=true'
-      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
-      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http'
+      # use dnschallenge instead od httpchallenge
+      # - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
+      # - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http'
       - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=hetzner'
       - '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=0'
       - '--certificatesresolvers.letsencrypt.acme.storage=/traefik/acme.json'

--- a/docs/knowledge-base/proxy/traefik/wildcard-certs.md
+++ b/docs/knowledge-base/proxy/traefik/wildcard-certs.md
@@ -62,7 +62,7 @@ services:
       - '--providers.docker.exposedbydefault=false'
       - '--providers.file.directory=/traefik/dynamic/'
       - '--providers.file.watch=true'
-      # use dnschallenge instead od httpchallenge
+      # use dnschallenge instead of httpchallenge
       # - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
       # - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http'
       - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=hetzner'


### PR DESCRIPTION
My setup didnt work until I made sure to only use one challenge for the letsencrypt resolver. Internet seems to point in the direction  that traefik isnt happy if setting both a dns and http challenge for a resolver. I havent verified this in traefik dos, but it started working for me when making the change.