### PR TITLE
Replace missleading OR

### DIFF
--- a/docs/knowledge-base/server/firewall.md
+++ b/docs/knowledge-base/server/firewall.md
@@ -26,7 +26,7 @@ For self-hosting Coolify, you need to allow some ports on your firewall.
 - [Detailed Guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses).
 
 #### Webhooks
-You need to allow TCP port `80` or `443` for GitHub webhooks.
+You need to allow TCP port `80` and `443` for GitHub webhooks.
 
 To specify the IP addresses (optional), you can use the following API endpoint to get them:
 


### PR DESCRIPTION
Spent some time debugging why my auto deploys don't work. Docs say I need to allow 80 or 443, but in reality it was **and**

as seen at https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses

> For applications to function, you must allow TCP **ports 22, 80, and 443** via our IP ranges for github.com.