### PR TITLE
Update martin.md

### DIFF
--- a/docs/services/martin.md
+++ b/docs/services/martin.md
@@ -13,4 +13,4 @@ Martin is a tile server able to generate and serve vector tiles on the fly from 
 
 ## Links
 
-- [Official Documentation](https://maplibre.org/martin/introduction.html/?utm_source=coolify.io)
+- [Official Documentation](https://maplibre.org/martin/introduction.html?utm_source=coolify.io)


### PR DESCRIPTION
Removed trailing slash from the official docs link since it breaks Martin's docs page