### PR TITLE
docs(services): fix broken Metabase image link

### DIFF
--- a/docs/services/metabase.md
+++ b/docs/services/metabase.md
@@ -3,7 +3,7 @@ title: "Metabase"
 description: "Here you can find the documentation for hosting Metabase with Coolify."
 ---
 
-![Metabase](https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.svg)
+![Metabase](https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.png)
 
 ## What is Metabase?
 


### PR DESCRIPTION
The previous svg link was broken. Changed it to the proper one

[https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.svg](https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.svg)
to
[https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.png](https://github.com/metabase/metabase/raw/master/docs/images/metabase-product-screenshot.png)