### PR TITLE
Adds warning to show that the hostname order for single resource tunnel matters

### DIFF
--- a/docs/knowledge-base/cloudflare/tunnels/single-resource.md
+++ b/docs/knowledge-base/cloudflare/tunnels/single-resource.md
@@ -166,6 +166,10 @@ Follow [Step 2](#_2-create-a-cloudflare-tunnel) from the main guide to create pu
 
 - **Type**: HTTP (Ensure you select HTTP for each hostname.)
 
+::: warning HEADS UP!
+The order of the hostnames matters! Be sure to match it exactly as shown above.
+:::
+
 ---
 
 ### 2. Update Coolify’s `.env` File


### PR DESCRIPTION
Hey!

I spent a good 30 minutes figuring out why my Websocket terminal wasn't working even though my hostnames were configured as shown. I soon realised that the order actually matters.

I believe this warning could help people in the future to avoid this mistake.

Thanks!