### PR TITLE
feat: Add Newt-Pangolin as service

### DIFF
--- a/docs/services/newt-pangolin.md
+++ b/docs/services/newt-pangolin.md
@@ -1,0 +1,16 @@
+---
+title: "Newt-Pangolin"
+description: "Here you can find the documentation for hosting Newt with Coolify."
+---
+
+<ZoomableImage src="/docs/images/services/pangolin_newt.svg" />
+
+
+## What is Newt?
+A tunneling client for Pangolin.
+
+
+## Links
+
+- [The official website ›](https://docs.fossorial.io/Newt/overview?utm_source=coolify.io)
+- [GitHub ›](https://github.com/fosrl/newt?utm_source=coolify.io)


### PR DESCRIPTION
Newt is a fully user space [WireGuard](https://www.wireguard.com/) tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.