### PR TITLE
Convex: Extend docs by setup guide for admin key

### DIFF
--- a/docs/services/convex.md
+++ b/docs/services/convex.md
@@ -11,6 +11,16 @@ description: Here you can find the documentation for hosting Convex with Coolify
 
 Convex is the open-source reactive database for app developers.
 
+## How to Generate an Admin Key
+
+To generate an admin key for your Convex application in Coolify, follow these steps:
+1. Go to the Coolify dashboard.
+2. Select your Convex application.
+3. Open the Terminal tab.
+4. Connect to the backend terminal.
+5. In the terminal, execute the following command: `./generate_admin_key.sh`
+6. Copy the generated admin key for your records.
+
 ## Links
 
 - [Official Documentation](https://docs.convex.dev/?utm_source=coolify.io)


### PR DESCRIPTION
For Convex you need a special admin key, which is generated by a convex internal script.

Credits to Mukund from Discord