### PR TITLE
docs: fix misspellings in Laravel deploy example

### DIFF
--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -301,7 +301,7 @@ php_admin_value[post_max_size] = 256M
 
 1. Create a new resource from a private or public repository.
 2. Set the `Ports Exposes` field to `8000`, for example.
-3. Set default environnement variables using `Developer view` in `Environment Variables`:
+3. Set default environment variables using `Developer view` in `Environment Variables`:
 
 ```sh
 APP_DEBUG=false
@@ -399,7 +399,7 @@ CMD ["unitd", "--no-daemon"]
 }
 ```
 > [!NOTE]
-> When using docker-compose for deployment, then there might be an issue with `Mixed content error` when some of the assets are requested via `http://` instead of `https://`. To avoid that, find your load blaancer/proxy subnet or IP address and add it to the unit.config to explicitly tell unit to forward the correct headers to Laravel. Laravel also has to be configured trust proxies. More on that [here](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).
+> When using docker-compose for deployment, then there might be an issue with `Mixed content error` when some of the assets are requested via `http://` instead of `https://`. To avoid that, find your load balancer/proxy subnet or IP address and add it to the unit.config to explicitly tell unit to forward the correct headers to Laravel. Laravel also has to be configured trust proxies. More on that [here](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).
 > ```json
 > "listeners": {
 >        "*:8000": {


### PR DESCRIPTION
## Description

This PR fixes two minor misspellings in the Laravel deployment example.

## Changes

- Changed `default environnement` to `default environment` in `docs/applications/laravel.md`.
- Changed `load blaancer` to `load balancer` in `docs/applications/laravel.md`.
