### PR TITLE
fix: lastUpdated support per page

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: [self-hosted, arm64]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/staging-build.yml
+++ b/.github/workflows/staging-build.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: [self-hosted, arm64]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Modified the gh workflow per VitePress docs information to support last updated dates per page basedo n commit logs.

<img width="1124" height="1016" alt="image" src="https://github.com/user-attachments/assets/d5fd8c73-c69a-450f-80e6-f81865300084" />


OG issue: https://github.com/coollabsio/coolify-docs/issues/255