### PR TITLE
Docker Docs: Replace Legacy Link with Updated URL

### DIFF
--- a/docs/applications/index.md
+++ b/docs/applications/index.md
@@ -154,7 +154,7 @@ You can rollback to a previous version of your resource. At the moment, only loc
 
 ### Resource Limits
 
-By default, the container won't have any resource limits. You can set the limits here. For more details, read the [Docker documentation](https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu_count-cpu_percent-cpu_shares-cpu_period-cpu_quota-cpus-cpuset-domainname-hostname-ipc-mac_address-mem_limit-memswap_limit-mem_swappiness-mem_reservation-oom_kill_disable-oom_score_adj-privileged-read_only-shm_size-stdin_open-tty-user-working_dir).
+By default, the container won't have any resource limits. You can set the limits here. For more details, read the [Docker documentation](https://docs.docker.com/reference/compose-file/services).
 
 ## Deployment Types
 


### PR DESCRIPTION
The old link was no longer up to date and redirected to a legacy page. I have now inserted the current link.