### PR TITLE
docs: content is not valid for volumes, replace example with configs instead

### DIFF
--- a/docs/knowledge-base/docker/compose.md
+++ b/docs/knowledge-base/docker/compose.md
@@ -97,6 +97,26 @@ services:
     image: filebrowser/filebrowser:latest
     environment:
       - POSTGRES_PASSWORD=password
+    volumes:
+      - type: bind
+        source: ./srv/99-roles.sql
+        target: /docker-entrypoint-initdb.d/init-scripts/99-roles.sql
+        content: |  # This will tell Coolify to create the file (this is not available in a normal docker-compose)
+          -- NOTE: change to your own passwords for production environments
+           \set pgpass `echo "$POSTGRES_PASSWORD"`
+
+           ALTER USER authenticator WITH PASSWORD :'pgpass';
+           ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+```
+
+Alternatively config files can be created using the [configs](https://docs.docker.com/reference/compose-file/configs/) top level element in Docker Compose.
+
+```yaml
+services:
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    environment:
+      - POSTGRES_PASSWORD=password
     configs:
       - source: roles
         target: /docker-entrypoint-initdb.d/init-scripts/99-roles.sql

--- a/docs/knowledge-base/docker/compose.md
+++ b/docs/knowledge-base/docker/compose.md
@@ -97,16 +97,18 @@ services:
     image: filebrowser/filebrowser:latest
     environment:
       - POSTGRES_PASSWORD=password
-    volumes:
-      - type: bind
-        source: ./srv/99-roles.sql
+    configs:
+      - source: roles
         target: /docker-entrypoint-initdb.d/init-scripts/99-roles.sql
-        content: |
-          -- NOTE: change to your own passwords for production environments
-           \set pgpass `echo "$POSTGRES_PASSWORD"`
 
-           ALTER USER authenticator WITH PASSWORD :'pgpass';
-           ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+configs:
+  roles:
+    content: |
+      -- NOTE: change to your own passwords for production environments
+        \set pgpass `echo "$POSTGRES_PASSWORD"`
+
+        ALTER USER authenticator WITH PASSWORD :'pgpass';
+        ALTER USER pgbouncer WITH PASSWORD :'pgpass';
 ```
 
 ## Exclude from healthchecks


### PR DESCRIPTION
"content" is not part of volumes in compose spec. I've updated example to match desired outcome "Here you can see how to add a file with content and a dynamic value that is coming from an environment variable." with `configs` instead.