### PR TITLE
docs: add note for server-side rendering

### DIFF
--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -269,6 +269,28 @@ stdout_logfile=/var/log/worker-inertia-ssr.log
 '''
 ```
 
+> [!NOTE]
+> Per default, Nixpacks runs the command `npm run build` to build your application during the deployment. Ensure that your `build` script in `package.json` contains the necessary build commands for server-side rendering. If you use one of the official starter kits including Inertia.js, change your scripts like this:
+> ```diff
+> "scripts": {
+>-     "build": "vite build",
+>+     "build": "vite build && vite build --ssr",
+>     "build:ssr": "vite build && vite build --ssr",
+> }
+> ```
+> Alternatively, if you don't want to adapt your default `build` script in `package.json`, you can add the correct build command for server-side rendering directly in your `nixpacks.toml` configuration file.
+>```diff
+>[phases.build]
+>cmds = [
+>+    "npm run build:ssr",
+>    "mkdir -p /etc/supervisor/conf.d/",
+>    "cp /assets/worker-*.conf /etc/supervisor/conf.d/",
+>    "cp /assets/supervisord.conf /etc/supervisord.conf",
+>    "chmod +x /assets/start.sh",
+>    "..."
+> ]
+>```
+
 ### Persistent php.ini customizations
 
 If you want to customize settings from your php.ini file, you can easily do so by using the `php_admin_value` directive and appending them to your `php-fpm.conf` file like this:


### PR DESCRIPTION
Added a note to the docs since additional config is required to support SSR for Laravel + Inertia.js applications deployed on Coolify using Nixpacks.