### PR TITLE
Add Gateway Timeout (504) Troubleshooting Documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -438,7 +438,7 @@ export default defineConfig({
             text: 'Applications',
             collapsed: true,
             items: [
-              { text: 'Bad Gateway', link: '/troubleshoot/applications/bad-gateway.md' },
+              { text: 'Bad Gateway (502)', link: '/troubleshoot/applications/bad-gateway.md' },
               { text: 'Gateway Timeout (504)', link: '/troubleshoot/applications/gateway-timeout' },
               { text: 'Failed To Get Access Token During Deployment', link: '/troubleshoot/applications/failed-to-get-token' },
             ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -439,6 +439,7 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: 'Bad Gateway', link: '/troubleshoot/applications/bad-gateway.md' },
+              { text: 'Gateway Timeout (504)', link: '/troubleshoot/applications/gateway-timeout' },
               { text: 'Failed To Get Access Token During Deployment', link: '/troubleshoot/applications/failed-to-get-token' },
             ]
           },

--- a/docs/knowledge-base/destinations/manage.md
+++ b/docs/knowledge-base/destinations/manage.md
@@ -69,7 +69,7 @@ Unlike applications or databases, service stacks are not by default connected to
 If you want to connect a service stack to a destination, enable [Connect to Predefined Networks](/knowledge-base/docker/compose#connect-to-predefined-networks) in it's settings. This allows the service stack to communicate with other resources on the same destination.
 
 ::: danger WARNING
-Avoid defining network configurations directly in your service stack's `docker-compose.y[a]ml` and instead use Coolify's Destination settings to manage network connections. This could otherwise lead to undesired behavior, such as **Gateway Timeout** errors.
+Avoid defining network configurations directly in your service stack's `docker-compose.y[a]ml` and instead use Coolify's Destination settings to manage network connections. This could otherwise lead to undesired behavior, such as [Gateway Timeout](/troubleshoot/applications/gateway-timeout) errors.
 :::
 
 ## Best Practices

--- a/docs/troubleshoot/applications/bad-gateway.md
+++ b/docs/troubleshoot/applications/bad-gateway.md
@@ -1,8 +1,10 @@
 ---
 title: Bad Gateway Error
+description: Troubleshooting Bad Gateway (502) errors in Coolify applications and services.
+tags: ["Bad Gateway", "502", "Troubleshooting", "Coolify", "Traefik"]
 ---
 
-# Bad Gateway Error
+# Bad Gateway (502) Error
 
 If your deployed application **maybe** works when you access it via your server’s IP address and port but shows a **Bad Gateway** error on your domain, the issue is most often due to misconfigured port settings, incorrect host mapping, or your app listening only on localhost.
 

--- a/docs/troubleshoot/applications/gateway-timeout.md
+++ b/docs/troubleshoot/applications/gateway-timeout.md
@@ -1,0 +1,273 @@
+---
+title: Gateway Timeout Errors
+description: Troubleshooting Gateway Timeout (504) errors in Coolify applications and services.
+tags:
+  [
+    "Gateway Timeout",
+    "504",
+    "Troubleshooting",
+    "Coolify",
+    "Traefik",
+    "Caddy",
+    "Nginx",
+  ]
+---
+
+# Gateway Timeout (504) Errors
+
+Gateway timeout errors occur when the Coolify proxy cannot get a response from your application within the configured timeout period. This is different from Bad Gateway (502) errors, which indicate the proxy cannot connect to your application at all.
+
+## Common Causes
+
+There are two primary scenarios that cause 504 Gateway Timeout errors in Coolify:
+
+1. **Custom Docker Network Isolation** - The proxy cannot reach applications using custom networks
+2. **Large Upload/Download Timeouts** - Default timeout settings are too short for large file transfers
+
+## Issue 1: Custom Docker Network Isolation
+
+### Symptoms
+
+- Application works initially after deployment
+- 504 Gateway Timeout errors appear after hours or days
+- Application is reachable via direct IP and port
+- Restarting the application temporarily fixes the issue
+- Using custom Docker networks in your configuration
+
+### Root Cause
+
+When you define custom Docker networks in your Docker Compose file, the `coolify-proxy` container runs in Coolify's default network while your application runs in the custom network. This network isolation prevents the proxy from reaching your application, especially when Docker's internal DNS returns different IPs based on timing and network joins.
+
+### Diagnosis
+
+1. **Check if your application uses custom networks:**
+
+   ```bash
+   docker inspect <your-container-name> --format='{{range $k,$v := .NetworkSettings.Networks}}Network: {{$k}}, IP: {{$v.IPAddress}}, Gateway: {{$v.Gateway}}{{println}}{{end}}'
+   ```
+
+2. **Verify proxy network connections:**
+
+   ```bash
+   docker inspect coolify-proxy --format='{{range $k,$v := .NetworkSettings.Networks}}Network: {{$k}}, IP: {{$v.IPAddress}}, Gateway: {{$v.Gateway}}{{println}}{{end}}'
+   ```
+
+### Solutions
+
+#### Solution 1: Use Coolify Destinations (Recommended)
+
+Let Coolify manage networks automatically by using Destinations instead of custom networks:
+
+1. Remove custom network definitions from your Docker Compose file
+2. Configure the network destination in Coolify's UI under **Destinations**
+3. Redeploy your application
+
+**Before (problematic):**
+
+```yaml
+services:
+  app:
+    image: myapp:latest
+    networks:
+      - custom-network
+
+networks:
+  custom-network:
+    driver: bridge
+```
+
+**After (recommended):**
+
+```yaml
+services:
+  app:
+    image: myapp:latest
+    # Let Coolify handle networking
+```
+
+#### Solution 2: Manual Network Connection (Temporary)
+
+If you must use custom networks, manually connect the proxy:
+
+```bash
+docker network connect <your-network-name> coolify-proxy
+```
+
+**Note:** This is a temporary fix that may need to be reapplied after proxy restarts.
+
+#### Solution 3: Add Health Checks
+
+Adding health checks can help maintain network connectivity:
+
+```yaml
+services:
+  app:
+    image: myapp:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+```
+
+## Issue 2: Large Upload/Download Timeouts
+
+### Symptoms
+
+- 504 errors when uploading large files (>100MB)
+- 504 errors when pushing large Docker images to a registry
+- 504 errors during long-running requests (>60 seconds for Traefik/Nginx)
+- Small files and quick requests work fine
+
+### Root Cause
+
+The default timeout behavior depends on your proxy:
+
+- **Traefik**: Default read timeout is 60 seconds
+- **Caddy**: No default timeout (requests can run indefinitely)
+- **Nginx** (one-click databases): Default timeout is 60 seconds
+
+Any request exceeding the configured timeout will result in a 504 Gateway Timeout error, even if the backend application is still processing the request.
+
+### Diagnosis
+
+1. **Check which proxy you're using:**
+
+   - Navigate to **Servers > [YourServer] > Proxy** in the Coolify UI
+   - The proxy type (Traefik, Caddy, etc.) will be displayed
+
+2. **Check current proxy configuration:**
+
+   - Navigate to **Servers > [YourServer] > Proxy** and look for any timeout settings
+   - Check your applications / services for custom labels that might override defaults
+
+3. **Monitor request duration in application logs:**
+
+   - Navigate to your application / service logs in Coolify
+   - Look for long-running requests that exceed 60 seconds
+
+4. **Test with a smaller file to confirm it's size-related**
+
+### Solutions
+
+#### Solution 1: Increase Proxy Timeout
+
+The configuration method depends on your proxy type:
+
+##### For Traefik (Default Proxy)
+
+Add custom Traefik configuration to increase the timeout. You have various options depending on your needs to achieve this:
+
+1. Navigate to your application settings in Coolify
+2. Add the following to your **Container Labels**:
+
+```yaml
+# For 5-minute timeout
+traefik.http.services.<service-name>.loadbalancer.timeout.read=300s
+traefik.http.services.<service-name>.loadbalancer.timeout.write=300s
+traefik.http.services.<service-name>.loadbalancer.timeout.idle=300s
+```
+
+Or navigate to your server's proxy settings and add global timeouts under the command section:
+
+```yaml
+command:
+  - "--entrypoints.https.transport.respondingTimeouts.readTimeout=5m"
+  - "--entrypoints.https.transport.respondingTimeouts.writeTimeout=5m"
+  - "--entrypoints.https.transport.respondingTimeouts.idleTimeout=5m"
+```
+
+Read more about Traefik timeouts in the [official documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#timeout).
+
+##### For Caddy
+
+Since Caddy has no default timeout, you typically won't experience timeout issues. However, if you need to SET a timeout (for security or resource management):
+
+1. Add the following to your **Container Labels** in Coolify:
+
+```yaml
+# Set a 5-minute timeout (300 seconds)
+caddy.servers.timeouts.read_body=300s
+caddy.servers.timeouts.read_header=300s
+caddy.servers.timeouts.write=300s
+caddy.servers.timeouts.idle=5m
+```
+
+Read more about Caddy timeouts in the [official documentation](https://caddyserver.com/docs/caddyfile/options#timeouts).
+
+##### For Nginx (One-Click Databases)
+
+Nginx configuration cannot be directly modified for one-click databases in Coolify. Instead, **bypass Nginx entirely** to avoid timeout issues:
+
+1. Navigate to your database settings in Coolify
+2. **Disable** "Make it publicly available?" option
+3. Use **Port Mappings** instead to expose the database port directly and restart the database
+4. This maps the port directly from the container, bypassing Nginx and its timeout limitations
+
+**Example:** For a PostgreSQL database, map port `5432:5432` to access it directly without any proxy timeouts.
+
+#### Solution 2: Implement Chunked Uploads
+
+For very large files, consider implementing chunked uploads in your application:
+
+1. Split large files into smaller chunks on the client side
+2. Upload chunks individually (each under the timeout limit)
+3. Reassemble on the server side
+
+#### Solution 3: Use Background Processing
+
+For long-running operations:
+
+1. Accept the request and return immediately with a job ID
+2. Process the request in the background
+3. Provide an endpoint to check job status
+
+## Quick Diagnosis Checklist
+
+Run through these steps to identify your specific issue:
+
+1. **Check the error code:**
+
+   - 504 = Gateway Timeout (this guide)
+   - 502 = Bad Gateway (see [Bad Gateway troubleshooting](/troubleshoot/applications/bad-gateway))
+
+2. **Check timing:**
+
+   - Immediate = likely network/configuration issue
+   - After ~60 seconds = likely timeout issue
+   - Random after hours/days = likely network isolation issue
+
+3. **Check network configuration:**
+
+   ```bash
+   # List all Docker networks
+   docker network ls
+
+   # Check which networks your containers are using
+   docker ps --format "table {{.Names}}\t{{.Networks}}"
+   ```
+
+## Prevention Tips
+
+1. **Avoid custom Docker networks** unless absolutely necessary
+2. **Set appropriate timeouts** for your application's needs during initial setup
+3. **Implement health checks** to maintain connectivity
+4. **Monitor proxy logs** regularly for timeout patterns
+5. **Use progress indicators** for long-running operations to prevent client-side timeouts
+
+## Support
+
+If these solutions don't resolve your gateway timeout issues:
+
+1. Collect diagnostic information:
+
+   ```bash
+   # Save this output
+   docker ps --format "table {{.Names}}\t{{.Networks}}\t{{.Status}}"
+   docker logs coolify-proxy --tail 200 > proxy-logs.txt
+   docker logs <your-container-name> --tail 200 > app-logs.txt
+   ```
+
+2. Join our [Discord community](https://coolify.io/discord)
+3. Share your configuration, logs, and the specific steps you've tried

--- a/docs/troubleshoot/applications/gateway-timeout.md
+++ b/docs/troubleshoot/applications/gateway-timeout.md
@@ -36,7 +36,7 @@ There are two primary scenarios that cause 504 Gateway Timeout errors in Coolify
 
 ### Root Cause
 
-When you define custom Docker networks in your Docker Compose file, the `coolify-proxy` container runs in Coolify's default network while your application runs in the custom network. This network isolation prevents the proxy from reaching your application, especially when Docker's internal DNS returns different IPs based on timing and network joins.
+When you define custom Docker networks in your Docker Compose file, the `coolify-proxy` container runs in Coolify's own networks while your application runs in the custom network. This network isolation prevents the proxy from reaching your application, especially when Docker's internal DNS returns different IPs based on timing and network joins.
 
 ### Diagnosis
 
@@ -95,22 +95,6 @@ docker network connect <your-network-name> coolify-proxy
 ```
 
 **Note:** This is a temporary fix that may need to be reapplied after proxy restarts.
-
-#### Solution 3: Add Health Checks
-
-Adding health checks can help maintain network connectivity:
-
-```yaml
-services:
-  app:
-    image: myapp:latest
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-```
 
 ## Issue 2: Large Upload/Download Timeouts
 

--- a/docs/troubleshoot/applications/gateway-timeout.md
+++ b/docs/troubleshoot/applications/gateway-timeout.md
@@ -15,7 +15,7 @@ tags:
 
 # Gateway Timeout (504) Errors
 
-Gateway timeout errors occur when the Coolify proxy cannot get a response from your application within the configured timeout period. This is different from Bad Gateway (502) errors, which indicate the proxy cannot connect to your application at all.
+Gateway timeout errors occur when the Coolify proxy cannot get a response from your application within the configured timeout period. This is different from [Bad Gateway (502)](troubleshoot/applications/bad-gateway) errors, which indicate the proxy cannot connect to your application at all.
 
 ## Common Causes
 
@@ -30,7 +30,7 @@ There are two primary scenarios that cause 504 Gateway Timeout errors in Coolify
 
 - Application works initially after deployment
 - 504 Gateway Timeout errors appear after hours or days
-- Application is reachable via direct IP and port
+- Application is reachable via direct IP and port (requires manual port mapping)
 - Restarting the application temporarily fixes the issue
 - Using custom Docker networks in your configuration
 
@@ -56,11 +56,12 @@ When you define custom Docker networks in your Docker Compose file, the `coolify
 
 #### Solution 1: Use Coolify Destinations (Recommended)
 
-Let Coolify manage networks automatically by using Destinations instead of custom networks:
+Let Coolify manage networks automatically by using [Destinations](/knowledge-base/destinations/) instead of custom networks:
 
 1. Remove custom network definitions from your Docker Compose file
-2. Configure the network destination in Coolify's UI under **Destinations**
-3. Redeploy your application
+2. [Configure the network destination](/knowledge-base/destinations/create) in Coolify's UI under **Destinations**
+3. [Move your application / service to the desired destination](/knowledge-base/destinations/manage#assign-resources-to-a-destination)
+4. Redeploy
 
 **Before (problematic):**
 

--- a/docs/troubleshoot/applications/gateway-timeout.md
+++ b/docs/troubleshoot/applications/gateway-timeout.md
@@ -163,7 +163,7 @@ command:
   - "--entrypoints.https.transport.respondingTimeouts.idleTimeout=5m"
 ```
 
-Read more about Traefik timeouts in the [official documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#timeout).
+Read more about Traefik timeouts in the [official documentation ↗](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#timeout).
 
 ##### For Caddy
 
@@ -179,7 +179,7 @@ caddy.servers.timeouts.write=300s
 caddy.servers.timeouts.idle=5m
 ```
 
-Read more about Caddy timeouts in the [official documentation](https://caddyserver.com/docs/caddyfile/options#timeouts).
+Read more about Caddy timeouts in the [official documentation ↗](https://caddyserver.com/docs/caddyfile/options#timeouts).
 
 ##### For Nginx (One-Click Databases)
 
@@ -191,6 +191,8 @@ Nginx configuration cannot be directly modified for one-click databases in Cooli
 4. This maps the port directly from the container, bypassing Nginx and its timeout limitations
 
 **Example:** For a PostgreSQL database, map port `5432:5432` to access it directly without any proxy timeouts.
+
+Read more about public database access here: [One-Click Databases](/databases/#ports-mapping-vs-public-port).
 
 #### Solution 2: Implement Chunked Uploads
 
@@ -254,5 +256,5 @@ If these solutions don't resolve your gateway timeout issues:
    docker logs <your-container-name> --tail 200 > app-logs.txt
    ```
 
-2. Join our [Discord community](https://coolify.io/discord)
+2. Join our [Discord Community ↗](https://coolify.io/discord)
 3. Share your configuration, logs, and the specific steps you've tried


### PR DESCRIPTION
## Summary

This PR adds comprehensive troubleshooting documentation for Gateway Timeout (504) errors in Coolify, addressing two major issues identified in the community:

- **Custom Docker Network Isolation** ([GitHub #4483](https://github.com/coollabsio/coolify/issues/4483))
- **Large Upload/Download Timeouts** ([GitHub #6474](https://github.com/coollabsio/coolify/issues/6474))

## What's Added

### New Documentation Page
- **File:** `docs/troubleshoot/applications/gateway-timeout.md`
- **Navigation:** Added to sidebar under `Troubleshoot > Applications`
- **SEO:** Includes proper frontmatter with title, description, and tags

### Key Features

#### 1. Comprehensive Issue Coverage
- **Network Isolation Issues**: Docker custom networks preventing proxy communication
- **Timeout Issues**: Default timeout limits causing large file upload failures
- Clear differentiation between 504 (timeout) and 502 (bad gateway) errors

#### 2. Multi-Proxy Support
- **Traefik**: 60-second default timeout with configuration examples
- **Caddy**: No default timeout with optional timeout configuration
- **Nginx**: One-click database timeout handling with port mapping workaround

#### 3. User-Friendly Diagnosis
- UI-based proxy identification (`Servers > [YourServer] > Proxy`)
- Step-by-step diagnostic commands
- Clear symptoms and timing indicators

#### 4. Practical Solutions
- **Network Issues**: Coolify Destinations vs custom networks
- **Timeout Issues**: Proxy-specific configuration examples
- **Nginx Workaround**: Port Mappings to bypass proxy limitations

#### 5. Support Resources
- Community Discord information
- Diagnostic data collection guide

## Technical Details

### Navigation Updates
- Updated `docs/.vitepress/config.mts` to include new page in sidebar
- Positioned logically after "Bad Gateway (502)" for user flow

### Documentation Structure
```
## Common Causes
## Issue 1: Custom Docker Network Isolation
  ### Symptoms / Root Cause / Diagnosis / Solutions
## Issue 2: Large Upload/Download Timeouts  
  ### Symptoms / Root Cause / Diagnosis / Solutions
## Quick Diagnosis Checklist
## Prevention Tips
## Support
```

### Code Examples Included
- Docker network diagnostic commands
- Traefik timeout configuration (labels + global)
- Caddy timeout configuration (labels)
- Health check implementation examples
- Port mapping configuration examples

## Benefits

1. **Reduces Support Burden**: Common timeout issues now have documented solutions
2. **Improves User Experience**: Clear diagnosis steps and multiple solution paths
3. **Community Knowledge**: Consolidates solutions from GitHub issues into docs
4. **Multi-Proxy Coverage**: Addresses all proxy types Coolify supports

## Testing Recommendations

- [x] Verify VitePress builds without errors
- [x] Check navigation links work correctly
- [x] Validate all external links (GitHub issues, Discord)
- [ ] Test code examples in different proxy configurations
- [x] Ensure responsive design on mobile devices

## Related Issues

- Resolves community questions about timeout errors
- Provides documentation for GitHub issues #4483 and #6474
- Complements existing "Bad Gateway (502)" documentation

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>