### PR TITLE
fix: manual github app docs incorrect

### DIFF
--- a/docs/knowledge-base/git/github/manually-setup-github-app.md
+++ b/docs/knowledge-base/git/github/manually-setup-github-app.md
@@ -9,22 +9,23 @@ Since `4.0.0-beta.399` you are able to change all the Github App details inside 
 
 
 ## On Github
-1. You will need the `App ID`, `Client ID`, a `Client Secret (generated)`, `Github App Name`, `Webhook Secret`. You can find these on your Github App configuration page.
-2. Generate a Private Key on your Github App configuration page (if you already have one, ignore this).
-
-
-3. Set the `Homepage URL` to `https://app.coolify.io`.
-4. Set the `Setup URL` to the following: `https://app.coolify.io/webhooks/source/github/install?source=<source_uuid>` where `source_uuid` will be the newly created source in Coolify.
-5. Activate `Webhook` and set the `Webhook URL` to `https://app.coolify.io/webhooks/source/github/events`
-6. Set the `Webhook Secret`.
-7. In the `Install App` section, Install the app to the organization you want to use.
-8. Copy the `Installation ID` from the URL of the page after you installed the Github App.
-9. In the `Permissions & Events` section, set the following permissions:
+1. Generate a Private Key on your Github App configuration page (if you already have one, ignore this).
+2. Set the `Homepage URL` to `https://app.coolify.io`.
+3. Set the `Setup URL` to the following: `https://app.coolify.io/webhooks/source/github/install?source=<source_uuid>` where `source_uuid` will be the newly created source in Coolify.
+4. Activate `Webhook` and set the `Webhook URL` to `https://app.coolify.io/webhooks/source/github/events`
+5. Set the `Webhook Secret`.
+6. In the `Install App` section, Install the app to the organization you want to use.
+7. Copy the `Installation ID` from the URL of the page after you installed the Github App.
+8. In the `Permissions` section, set the following permissions:
    Repository permissions:
     - Contents: read
     - Metadata: read
-    - Email: read
     - Pull Request: read & write (optional, if you want to use the pull request feature)
+   Account permissions:
+    - Email addresses: read
+9. In the `Subscribe to events` section, enable tho following events:
+    - Push
+    - Pull Request (optional, if you want to use the pull request feature)
 
 
 ## On Coolify
@@ -32,5 +33,6 @@ Since `4.0.0-beta.399` you are able to change all the Github App details inside 
 1. Go to the `Sources` page and click on the `+` button or edit the existing one.
 2. Fill the name and the organization name (optional). Press `Continue`.
 3. Click on the `Continue` button on the `Manual Installation` section.
-4. Enter the `Github App Name`, `App ID`, `Installation ID`, `Client ID`, `Client Secret` , `Webhook Secret`, select the `Private Key` you added in step 0 and `Save`.
-5. If you filled everything correctly, click on the `Sync Name` button. If no errors, then you are done.
+4. Enter the `Github App Name`, `App ID`, `Installation ID`, `Client ID`, `Client Secret` , `Webhook Secret` from the GitHub App configuration page.
+5. Select the `Private Key` you added in step 0 and `Save`.
+6. If you filled everything correctly, click on the `Sync Name` button. If no errors, then you are done.


### PR DESCRIPTION
The docs for manually creating a GitHub app don't include configuring the events and have some confusing language (namely, 'You will need the xxx' under the 'On GitHub' section, since you will only gain access to those *after* the app is created).