### PR TITLE
Fix links to services from the overview page

### DIFF
--- a/docs/.vitepress/theme/components/Services/List.vue
+++ b/docs/.vitepress/theme/components/Services/List.vue
@@ -2109,7 +2109,7 @@ const { preloadServices, handleImageError, hasImageError, isImageLoading, getFal
                 <div v-else v-for="category in filteredCategories" :key="category">
                     <h2 class="text-2xl font-bold mb-6 text-gray-900 dark:text-gray-100">{{ category }}</h2>
                     <div class="services-grid grid grid-cols-1 gap-6 rounded-lg">
-                        <a v-for="service in filteredServicesByCategory(category)" :key="service.name" :href="`/services/${service.slug}`"
+                        <a v-for="service in filteredServicesByCategory(category)" :key="service.name" :href="`/docs/services/${service.slug}`"
                             class="dark:default-soft rounded-lg shadow border border-gray-300 hover:border-purple-500 dark:hover:border-purple-400 transition-colors hover:cursor-pointer flex flex-col no-underline">
                             <div class="w-full h-full flex flex-col dark:default-soft rounded-t-xl p-3">
                                 <div class="font-bold text-md text-gray-900 mb-1 dark:text-gray-100">{{ service.name }}</div>


### PR DESCRIPTION
I have noticed the broken links on the overview page, and I have fixed them by adding `/docs` in front of every link.