### PR TITLE
Clarify automatic SSL/HTTPS certificate handling

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -410,6 +410,7 @@ export default defineConfig({
                   },
                 ]
               },
+              { text: 'FAQ', link: '/knowledge-base/faq' },
             ]
           }
         ],

--- a/docs/get-started/concepts.md
+++ b/docs/get-started/concepts.md
@@ -9,52 +9,52 @@ description: Learn core Coolify concepts including servers, resources, environme
 
 Many people start their self-hosting journey after discovering Coolify. If you’re one of them, here’s a list of a few concepts that could make your experience smoother.
 
-
 ## Servers
-A server is a computer designed to run applications or services, providing the necessary computing power for your projects. 
+
+A server is a computer designed to run applications or services, providing the necessary computing power for your projects.
 
 It can be either physical such as a machine you have at home, like a Raspberry Pi, or one rented from a hosting provider like Hetzner.
 
+## Resources
 
-## Resources 
-In Coolify, a resource refers to an application or service you set up on your server—like a website, database, or API. 
+In Coolify, a resource refers to an application or service you set up on your server—like a website, database, or API.
 
-Each resource comes with its own configuration, like domains, backups, health checks, and so on. 
+Each resource comes with its own configuration, like domains, backups, health checks, and so on.
 
 Coolify offers a handy list of pre-set resources, called one-click services, that you can deploy instantly. But if you prefer, you can also deploy your own application easily.
 
-
 ## Environments
-In Coolify, a  environment is a tailored setup on your server that determines how your resources operate. 
 
-For instance, you could have a development environment for testing and debugging your code, alongside a production environment where your finished application goes live. 
+In Coolify, a environment is a tailored setup on your server that determines how your resources operate.
+
+For instance, you could have a development environment for testing and debugging your code, alongside a production environment where your finished application goes live.
 
 With Coolify, you can set up multiple environments on a single server, letting you switch between them effortlessly.
 
-
 ## Projects
-A project in Coolify is a group of environments and resources you’ve deployed on your server. 
 
-It serves as the highest-level structure in Coolify, organizing your deployment setup. 
+A project in Coolify is a group of environments and resources you’ve deployed on your server.
 
-You can manage multiple projects on the same server, each with its own unique set of environments and resources. 
+It serves as the highest-level structure in Coolify, organizing your deployment setup.
+
+You can manage multiple projects on the same server, each with its own unique set of environments and resources.
 
 For example, you might create one project for all your hobby-related resources and another for work-related ones.
 
-
 ## Containers
-In Coolify, everything you deploy runs as a Docker container, making it easy to manage and isolate your application. 
 
-You can use pre-built Docker images from public registries like Docker Hub or GitHub Container Registry to deploy without building them yourself. 
+In Coolify, everything you deploy runs as a Docker container, making it easy to manage and isolate your application.
 
-To deploy, you need a Docker image, either one you’ve built or one from someone else. 
+You can use pre-built Docker images from public registries like Docker Hub or GitHub Container Registry to deploy without building them yourself.
 
-If you’re coding your own app, Coolify can auto-build the image from a Dockerfile or Docker Compose file, though this resource-heavy process requires a capable server. 
+To deploy, you need a Docker image, either one you’ve built or one from someone else.
+
+If you’re coding your own app, Coolify can auto-build the image from a Dockerfile or Docker Compose file, though this resource-heavy process requires a capable server.
 
 Alternatively, you can build the image elsewhere, push it to a registry, and let Coolify deploy it as a container.
 
-
 ## Reverse Proxy
+
 A reverse proxy is a server or app that sits between your application and users, forwarding requests to the right place.
 
 Coolify includes two proxy options, Caddy and Traefik, which handle requests to your website by directing them to the container running your app.
@@ -63,17 +63,18 @@ This setup lets you run multiple applications on one server without tweaking con
 
 Plus, Coolify supports unlimited domains, so you could deploy 20 different apps, each with its own unique domain.
 
-The reverse proxy also automatically manages SSL/TLS certificates for your applications. When you enter a domain with `https://`, the proxy requests and installs certificates from Let's Encrypt automatically, with no manual configuration needed. Certificates are renewed automatically before they expire, keeping your applications secure without any intervention.
-
+The reverse proxy also automatically manages SSL/TLS certificates for your applications. When you enter a domain with `https://`, the proxy requests and installs certificates from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) automatically, with no manual configuration needed. Certificates are renewed automatically before they expire, keeping your applications secure without any intervention.
 
 ## Security
-Coolify doesn’t manage your server’s security or updates, that’s your responsibility to keep everything secure and up to date. 
+
+Coolify doesn’t manage your server’s security or updates, that’s your responsibility to keep everything secure and up to date.
 
 It’s built to simplify deployment management for you. While the Coolify core team plans to introduce more security features eventually, for now, securing your server is entirely up to you.
 
 ## Teams
-Coolify supports multiple users and teams, allowing each team to have its own projects and environments. 
 
-You can assign roles like admin to users, simplifying project management and collaboration on a single server. 
+Coolify supports multiple users and teams, allowing each team to have its own projects and environments.
+
+You can assign roles like admin to users, simplifying project management and collaboration on a single server.
 
 Currently, the teams feature isn’t fully polished for production use, but the Coolify core team plans to enhance it down the line.

--- a/docs/get-started/concepts.md
+++ b/docs/get-started/concepts.md
@@ -55,13 +55,15 @@ Alternatively, you can build the image elsewhere, push it to a registry, and let
 
 
 ## Reverse Proxy
-A reverse proxy is a server or app that sits between your application and users, forwarding requests to the right place. 
+A reverse proxy is a server or app that sits between your application and users, forwarding requests to the right place.
 
-Coolify includes two proxy options, Caddy and Traefik, which handle requests to your website by directing them to the container running your app. 
+Coolify includes two proxy options, Caddy and Traefik, which handle requests to your website by directing them to the container running your app.
 
-This setup lets you run multiple applications on one server without tweaking configs or ports. 
+This setup lets you run multiple applications on one server without tweaking configs or ports.
 
 Plus, Coolify supports unlimited domains, so you could deploy 20 different apps, each with its own unique domain.
+
+The reverse proxy also automatically manages SSL/TLS certificates for your applications. When you enter a domain with `https://`, the proxy requests and installs certificates from Let's Encrypt automatically, with no manual configuration needed. Certificates are renewed automatically before they expire, keeping your applications secure without any intervention.
 
 
 ## Security

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -39,6 +39,14 @@ If automatic certificate issuance from Let's Encrypt fails, Coolify will provide
 If you see a certificate warning in your browser or your application shows a self-signed certificate, see the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.
 :::
 
+## Catch Multiple Domains
+
+Multitenancy is supported with Coolify. When using [Traefik](/knowledge-base/proxy/traefik/overview), you can automatically catch multiple domains, by editing the `Container Labels` of your Application or Service and define a [`HostRegexp`](https://doc.traefik.io/traefik/reference/routing-configuration/http/routing/rules-and-priority/#host-and-hostregexp) rule.
+
+::: warning Catch-All & SSL Certificates
+The proxy won't be able to issue SSL certificates for catch-all domains. For subdomains of a specific domain, you have the option to generate a [Wildcard SSL certificate](/knowledge-base/proxy/traefik/wildcard-certs).
+:::
+
 ## Wildcard Domain
 
 You can set a wildcard domain (`example: http://example.com`) to your server, so you can easily assign generated domains to all the resources connected to this server. [More details](/knowledge-base/server/introduction#wildcard-domain)

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -4,6 +4,7 @@ description: "Add custom domains to Coolify with FQDN format, multiple domain su
 ---
 
 # Domains
+
 You can easily add your own domains to Coolify or your resources.
 
 All domain fields are capable to generate your proxy configurations based on the following rules:
@@ -33,13 +34,6 @@ You don't need to do anything special to enable HTTPS. Simply use `https://` whe
 ### Self-Signed Certificates as Fallback
 
 If automatic certificate issuance from Let's Encrypt fails, Coolify will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
-
-Common reasons for automatic certificate issuance failure:
-
-- DNS records are not properly configured or not yet propagated
-- Required ports (80 for HTTP challenge, 443 for TLS-ALPN challenge) are not accessible from the internet
-- Server firewall is blocking Let's Encrypt validation requests
-- Domain ownership validation fails due to proxy interference (e.g., Cloudflare with certain settings)
 
 ::: warning TROUBLESHOOTING
 If you see a certificate warning in your browser or your application shows a self-signed certificate, see the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -47,4 +47,4 @@ You can set a wildcard domain (`example: http://example.com`) to your server, so
 
 Since version `beta.191`, Coolify will validates DNS records for your domains with `1.1.1.1` Cloudflare DNS server.
 
-If you want to use different DNS server, go to your `Settings` page and change the `DNS Servers` field (comma separated list).
+If you want to use different DNS server, go to your `Settings > Advanced` page and change the `Custom DNS Servers` field (comma separated list).

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -12,6 +12,39 @@ All domain fields are capable to generate your proxy configurations based on the
 2. You can give multiple domains, separated by comma: `https://coolify.io,https://www.coolify.io`
 3. You can also add a port to the domain, so the proxy will know which port you would like to map to the domain: `https://coolify.io:8080,http://api.coolify.io:3000`
 
+## HTTPS & SSL Certificates
+
+Coolify automatically handles SSL/TLS certificates for your applications. When you enter a domain with the `https://` protocol, everything is configured for you behind the scenes.
+
+### How Automatic HTTPS Works
+
+When you enter a domain using the `https://` protocol (for example, `https://example.com`):
+
+1. **Automatic Proxy Configuration** - Coolify automatically applies the necessary configuration to your reverse proxy (Traefik or Caddy) to serve your application over HTTPS.
+
+2. **Certificate Issuance** - The proxy automatically starts the process to request and install SSL certificates from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io).
+
+3. **Automatic Renewal** - Certificates are automatically renewed before they expire. Let's Encrypt certificates are valid for 90 days and Coolify handles renewals seamlessly.
+
+::: success TIP
+You don't need to do anything special to enable HTTPS. Simply use `https://` when entering your domain, and Coolify takes care of the rest.
+:::
+
+### Self-Signed Certificates as Fallback
+
+If automatic certificate issuance from Let's Encrypt fails, Coolify will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
+
+Common reasons for automatic certificate issuance failure:
+
+- DNS records are not properly configured or not yet propagated
+- Required ports (80 for HTTP challenge, 443 for TLS-ALPN challenge) are not accessible from the internet
+- Server firewall is blocking Let's Encrypt validation requests
+- Domain ownership validation fails due to proxy interference (e.g., Cloudflare with certain settings)
+
+::: warning TROUBLESHOOTING
+If you see a certificate warning in your browser or your application shows a self-signed certificate, see the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.
+:::
+
 ## Wildcard Domain
 
 You can set a wildcard domain (`example: http://example.com`) to your server, so you can easily assign generated domains to all the resources connected to this server. [More details](/knowledge-base/server/introduction#wildcard-domain)

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -31,7 +31,7 @@ When you enter a domain using the `https://` protocol (for example, `https://exa
 You don't need to do anything special to enable HTTPS. Simply use `https://` when entering your domain, and Coolify takes care of the rest.
 :::
 
-### Self-Signed Certificates as Fallback
+### Self-Signed Certificates
 
 If automatic certificate issuance from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) fails, the Coolify Proxy will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
 

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -33,7 +33,7 @@ You don't need to do anything special to enable HTTPS. Simply use `https://` whe
 
 ### Self-Signed Certificates as Fallback
 
-If automatic certificate issuance from Let's Encrypt fails, Coolify will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
+If automatic certificate issuance from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) fails, the Coolify Proxy will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
 
 ::: warning TROUBLESHOOTING
 If you see a certificate warning in your browser or your application shows a self-signed certificate, see the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.
@@ -44,7 +44,7 @@ If you see a certificate warning in your browser or your application shows a sel
 Multitenancy is supported with Coolify. When using [Traefik](/knowledge-base/proxy/traefik/overview), you can automatically catch multiple domains, by editing the `Container Labels` of your Application or Service and define a [`HostRegexp`](https://doc.traefik.io/traefik/reference/routing-configuration/http/routing/rules-and-priority/#host-and-hostregexp) rule.
 
 ::: warning Catch-All & SSL Certificates
-The proxy won't be able to issue SSL certificates for catch-all domains. For subdomains of a specific domain, you have the option to generate a [Wildcard SSL certificate](/knowledge-base/proxy/traefik/wildcard-certs).
+The Coolify Proxy won't be able to issue SSL certificates for catch-all domains. For subdomains of a specific domain, you have the option to generate a [Wildcard SSL certificate](/knowledge-base/proxy/traefik/wildcard-certs).
 :::
 
 ## Wildcard Domain

--- a/docs/knowledge-base/faq.md
+++ b/docs/knowledge-base/faq.md
@@ -52,3 +52,18 @@ Documentation: https://developers.cloudflare.com/ssl/origin-configuration/ssl-mo
 
 ### How to map a port the server?
 If you want to map a port the host system (server), you need to use [Ports Mappings](/applications/#port-mappings) feature.
+
+## SSL & HTTPS
+
+### How do I enable HTTPS/SSL for my application?
+HTTPS is automatically enabled when you enter a domain using the `https://` protocol (for example, `https://example.com`). Coolify will automatically configure your reverse proxy and request SSL certificates from Let's Encrypt. You don't need to do any additional setup.
+
+For more details, see the [Domains documentation](/knowledge-base/domains#https-ssl-certificates).
+
+### My application is showing a certificate warning in the browser. What should I do?
+If your browser shows a certificate warning or indicates a self-signed certificate, it means the automatic certificate issuance from Let's Encrypt failed. This is usually due to DNS configuration issues, firewall problems, or port accessibility.
+
+See the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.
+
+### Do SSL certificates renew automatically?
+Yes. Coolify automatically renews SSL certificates from Let's Encrypt before they expire. Let's Encrypt certificates are valid for 90 days, and Coolify handles all renewals seamlessly in the background.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation about Coolify's automatic SSL/HTTPS certificate handling across three strategic locations. This addresses a common documentation gap where users search for "how to enable SSL" without realizing it's automatic when using `https://` in the domain field.

### Background & Motivation

Analysis of **Trieve AI search statistics** from the docs shows that SSL and domains are among the **most frequently searched topics**. Additionally, frequent questions about SSL setup appear on **Discord**, indicating users are unclear about how automatic certificate handling works in Coolify.

This PR addresses this gap with proactive documentation rather than just reactive troubleshooting.

### Changes Made

1. **[knowledge-base/domains.md](docs/knowledge-base/domains.md)** - Added comprehensive "HTTPS & SSL Certificates" section explaining:
   - How automatic HTTPS works when using `https://` protocol
   - The 3-step automatic process (proxy config → certificate issuance → renewal)
   - Self-signed certificate fallback behavior
   - Common failure reasons with link to troubleshooting

2. **[get-started/concepts.md](docs/get-started/concepts.md)** - Enhanced "Reverse Proxy" section with automatic SSL/TLS certificate management info to educate new users early in their journey

3. **[knowledge-base/faq.md](docs/knowledge-base/faq.md)** - Added new "SSL & HTTPS" section with 3 common questions:
   - How to enable HTTPS/SSL
   - Certificate warning troubleshooting
   - Automatic renewal confirmation

### Problem Solved

Users frequently search for SSL setup instructions, not realizing that:
- HTTPS is automatically enabled when using `https://` protocol in domain field
- Coolify automatically configures the proxy
- Let's Encrypt certificates are automatically issued and renewed
- Self-signed certificates are provided as fallback when automatic issuance fails

### Documentation Strategy

- **Proactive education** in [domains.md](docs/knowledge-base/domains.md) (where users configure domains)
- **Early awareness** in [concepts.md](docs/get-started/concepts.md) (for new users)
- **Quick reference** in [faq.md](docs/knowledge-base/faq.md) (for users searching)
- **Cross-linking** to existing [troubleshooting guide](docs/troubleshoot/dns-and-domains/lets-encrypt-not-working.md)

## Test plan

- [x] Verify markdown rendering locally with `bun run dev`
- [x] Check all internal links resolve correctly
- [x] Ensure consistent terminology with existing docs
- [x] Validate VitePress formatting (callouts, links, headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)