### PR TITLE
Update default password value

### DIFF
--- a/docs/services/filebrowser.md
+++ b/docs/services/filebrowser.md
@@ -16,7 +16,7 @@ Filebrowser provides a file managing interface within a specified directory and 
 - Deploy Filebrowser using Coolify template
 - In the Filebrowser UI login with credentials:
   - Username: `admin`
-  - Password: `admin`
+  - Password: randomly generated, viewable in the logs
 
 ## Screenshots
 


### PR DESCRIPTION
The Coolify docs are outdated. Filebrowser currently generates a random password and sends it in the logs.

Source: https://filebrowser.org/installation.html#first-boot