### PR TITLE
feat: enable automatic external link icons

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
   ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
+    externalLinkIcon: true,
     carbonAds: {
       code: 'CW7IPKJJ',
       placement: 'coolifyio'

--- a/docs/builds/introduction.md
+++ b/docs/builds/introduction.md
@@ -7,37 +7,37 @@ description: Deploy applications as Docker containers with Coolify using build p
 
 <br />
 
-Coolify deploys all applications as Docker containers. This means your app, database, or website runs inside a container. 
+Coolify deploys all applications as Docker containers. This means your app, database, or website runs inside a container.
 
 No matter what you deploy or which build pack you use, it is always run as a Docker container.
 
-
 ## How Docker Containers Work
-- **Docker Image:** To run a container, you need a Docker image.  
-- **Dockerfile:** The image is built using a Dockerfile, just a file with step-by-step instructions to build the docker image.
-- **Build Process:**  If you're building your own application, you'll need to create your docker image using a Dockerfile. 
-    - Coolify helps with this build process by letting you use different build packs. A commonly used build pack is [Nixpacks ↗](https://nixpacks.com?utm_source=coolify.io), which automatically prepares a Dockerfile and builds the docker image for you.
 
+- **Docker Image:** To run a container, you need a Docker image.
+- **Dockerfile:** The image is built using a Dockerfile, just a file with step-by-step instructions to build the docker image.
+- **Build Process:** If you're building your own application, you'll need to create your docker image using a Dockerfile.
+  - Coolify helps with this build process by letting you use different build packs. A commonly used build pack is [Nixpacks](https://nixpacks.com?utm_source=coolify.io), which automatically prepares a Dockerfile and builds the docker image for you.
 
 ## Build Packs in Coolify
-Coolify offers build packs like [Nixpack ↗](https://nixpacks.com?utm_source=coolify.io) and **Static Build Pack** that automatically create your Docker image. 
+
+Coolify offers build packs like [Nixpack](https://nixpacks.com?utm_source=coolify.io) and **Static Build Pack** that automatically create your Docker image.
 
 If you need more control over the process, you can write your own Dockerfile and Docker Compose file. In that case, Coolify will use your file to build the image on the server and deploy it as a container.
 
-
 ## Using Pre-built Images
-If you already have a Docker image stored in a registry (for example, [Docker Hub ↗](https://hub.docker.com/?utm_source=coolify.io) or [GitHub Container Registry ↗](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry?utm_source=coolify.io)), you can use that image directly in Coolify. This means you do not have to rebuild the image on your server.
 
+If you already have a Docker image stored in a registry (for example, [Docker Hub](https://hub.docker.com/?utm_source=coolify.io) or [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry?utm_source=coolify.io)), you can use that image directly in Coolify. This means you do not have to rebuild the image on your server.
 
-## Managing Build Resources  
-Building Docker images can consume a lot of resources on your server, potentially causing it to crash. 
+## Managing Build Resources
 
-To reduce the load on your main server, Coolify allows you to connect additional servers to manage the build process.  
+Building Docker images can consume a lot of resources on your server, potentially causing it to crash.
 
-You can set up a separate [build server ↗](/builds/servers) to handle the builds, or use external tools like [GitHub Actions ↗](https://github.com/features/actions?utm_source=coolify.io) to build your images and push them to any container registry. 
+To reduce the load on your main server, Coolify allows you to connect additional servers to manage the build process.
+
+You can set up a separate [build server](/builds/servers) to handle the builds, or use external tools like [GitHub Actions](https://github.com/features/actions?utm_source=coolify.io) to build your images and push them to any container registry.
 
 Once the images are pushed, you can easily use them on Coolify.
 
-
 ## What's Next?
+
 Check the pages in the sidebar to learn more about build packs, build commands, and build servers.

--- a/docs/builds/packs/docker-compose.md
+++ b/docs/builds/packs/docker-compose.md
@@ -24,7 +24,7 @@ On the Coolify dashboard, open your project and click the **Create New Resource*
 
 **A.** If your Git repository is public, choose the **Public Repository** option.
 
-**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App ↗](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key ↗](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
+**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
 
 ### 3. Select Your Git Repository
 

--- a/docs/builds/packs/dockerfile.md
+++ b/docs/builds/packs/dockerfile.md
@@ -7,17 +7,17 @@ description: Build Docker images from your custom Dockerfile with Coolify suppor
 
 <br />
 
-Dockerfile includes step-by-step instructions to build a Docker image that Coolify uses to deploy your application or website. 
+Dockerfile includes step-by-step instructions to build a Docker image that Coolify uses to deploy your application or website.
 
 The Dockerfile build pack allows you to use your own Dockerfile to deploy your application, you have complete control over how your application is built and deployed on Coolify.
 
-
 ## How to use Dockerfile?
+
 ### 1. Create a New Resource in Coolify
+
 On the Coolify dashboard, open your project and click the **Create New Resource** button.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/1.webp" alt="Coolify dashboard screenshot" />
-
 
 ### 2. Choose Your Deployment Option
 
@@ -25,22 +25,22 @@ On the Coolify dashboard, open your project and click the **Create New Resource*
 
 **A.** If your Git repository is public, choose the **Public Repository** option.
 
-**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App ↗](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key ↗](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
-
+**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
 
 ### 3. Select Your Git Repository
+
 If you are using a public repository, paste the URL of your GitHub repository when prompted. The steps are very similar for all other options.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/3.webp" alt="Coolify dashboard screenshot" />
 
-
 ### 4. Choose the Build Pack
+
 Coolify defaults to using Nixpacks. Click the Nixpacks option and select **Dockerfile** as your build pack from the dropdown menu.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/4.webp" alt="Coolify dashboard screenshot" />
 
-
 ### 5. Configure the Build Pack
+
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/5.webp" alt="Coolify dashboard screenshot" />
 
 - **Branch:** Coolify will automatically detect the branch in your repository.
@@ -48,43 +48,45 @@ Coolify defaults to using Nixpacks. Click the Nixpacks option and select **Docke
 
 Click on **Continue** button once you have set all the above settings to correct details.
 
-
 ### 6. Configure Network Settings
-After clicking **Continue**, update settings like your domain and environment variables (if needed). 
+
+After clicking **Continue**, update settings like your domain and environment variables (if needed).
 
 The important option is the port where your application runs.
 Coolify sets the default port to 3000, so if your application listens on a different port, update the port number on the network section.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/6.webp" alt="Coolify dashboard screenshot" />
 
-
 ## Advanced Configuration
+
 ### Environment Variables
-You can manage your environment variables from the Coolify UI. 
+
+You can manage your environment variables from the Coolify UI.
 
 Click on the **Environment Variables** tab to add or update them.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/7.webp" alt="Coolify dashboard screenshot" />
 
 ### Pre/Post Deployment Commands
+
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/8.webp" alt="Coolify dashboard screenshot" />
 - **Pre-deployment:** Optionally, specify a script or command to execute in the existing container before deployment begins. This command is run with `sh -c`, so you do not need to add it manually.
 - **Post-deployment:** Optionally, specify a script or command to execute in the newly built container after deployment completes. This command is also executed with `sh -c`.
 
-
 ## Known Issues and Solutions
-::: details 1. Visiting the Application Domain Shows "No Available Server"
-If you see a "No Available Server" error when visiting your website, it is likely due to the health check for your container. 
 
-Run `docker ps` on your server terminal to check if your container is unhealthy or still starting.  
+::: details 1. Visiting the Application Domain Shows "No Available Server"
+If you see a "No Available Server" error when visiting your website, it is likely due to the health check for your container.
+
+Run `docker ps` on your server terminal to check if your container is unhealthy or still starting.
 
 To resolve this, fix the issue causing the container to be unhealthy or remove the health checks.
 :::
 
 ::: details 2. App only works inside the Container
-If your app works when you check it with a `curl localhost` inside the container but you receive a 404 or "No Available Server" error when accessing your domain, verify the port settings.  
+If your app works when you check it with a `curl localhost` inside the container but you receive a 404 or "No Available Server" error when accessing your domain, verify the port settings.
 
-Make sure that the port in the network settings matches the port where your application is listening. Also, check the startup log to ensure the application is not only listening on localhost. 
+Make sure that the port in the network settings matches the port where your application is listening. Also, check the startup log to ensure the application is not only listening on localhost.
 
 <ZoomableImage src="/docs/images/builds/packs/dockerfile/9.webp" alt="Coolify dashboard screenshot" />
 

--- a/docs/builds/packs/nixpacks.md
+++ b/docs/builds/packs/nixpacks.md
@@ -14,13 +14,14 @@ Nixpacks checks your git repository (also called as "**source directory**" in ni
 Nixpacks can deploy both fully static websites and non-static applications. Once your repository is set up, you can use Coolify to deploy your project with ease.
 
 ## How to use Nixpacks?
+
 On Coolify you can only use Nixpacks on git-based deployments.
 
 ### 1. Create a New Resource in Coolify
+
 On Coolify dashboard open your project and click the **Create New Resource** button.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/1.webp" alt="Coolify dashboard screenshot" />
-
 
 ### 2. Choose Your Deployment Option
 
@@ -28,26 +29,29 @@ On Coolify dashboard open your project and click the **Create New Resource** but
 
 **A.** If your Git repository is public, choose the **Public Repository** option.
 
-**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App ↗](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key ↗](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
-
+**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
 
 ### 3. Select Your Git Repository
+
 If you are using a public repository, paste the URL of your GitHub repository when prompted. The steps are very similar for all other options.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/3.webp" alt="Coolify dashboard screenshot" />
 
-
 ### 4. Choose the Build Pack
+
 Coolify will default to using Nixpacks. If it doesn’t, click to select Nixpacks as your build pack.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/4.webp" alt="Coolify dashboard screenshot" />
 
 ### 5. Configure Build Pack
+
 We have different options like Base Directory, Publish Directory, and Ports that slightly change based on the application you deploy (static websites/applications). So, below we have two sections for the deployments possible with Nixpacks.
+
 - [How to deploy Fully Static Websites](#how-to-deploy-fully-static-website)
 - [How to deploy Non-Static Website/Applications](#how-to-deploy-non-static-website-applications)
 
 ## How to deploy Fully Static Website?
+
 First, follow the previous section in this documentation: [How to use Nixpacks](#how-to-use-nixpacks). After that, proceed with the steps below.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/5.webp" alt="Coolify dashboard screenshot" />
@@ -55,6 +59,7 @@ First, follow the previous section in this documentation: [How to use Nixpacks](
 1. **Branch:** Coolify will automatically detect the branch from your Repostiory.
 
 2. **Base Directory:** Enter the directory Nixpacks should use as the root (for example, `/` if your files are at the root, or a subfolder if applicable).
+
    - If you have a monorepo then you can enter the path of the directory you want to use as base directory (`/backend` for example)
 
 3. **Is it a static Site?:** Click on this option to enable static mode.
@@ -69,31 +74,28 @@ First, follow the previous section in this documentation: [How to use Nixpacks](
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/6.webp" alt="Coolify dashboard screenshot" />
 
-- As of Coolify **v4.0.0-beta.404**, the only web server option available is [Nginx ↗](https://nginx.org/en/?utm_source=coolify.io). So **Nginx** will be selected by default.
+- As of Coolify **v4.0.0-beta.404**, the only web server option available is [Nginx](https://nginx.org/en/?utm_source=coolify.io). So **Nginx** will be selected by default.
 
 8. Click the **Deploy** button. The deployment process is usually quick (often less than a minute, depending on your server).
-
 
 9. Customize Your Web Server Configuration <Badge type="warning" text="Optional" />
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/7.webp" alt="Coolify dashboard screenshot" />
 
-- Coolify provides a default web server configuration that works for most cases. 
+- Coolify provides a default web server configuration that works for most cases.
 
 - If you want to change it then click the **Generate** button to load the default settings and make any changes you need.
-
 
 ::: warning HEADS UP!
 You have to click on the **Restart** button for the new configuration to take effect.
 :::
 
-
 ### How this works?
+
 Nixpacks will build the website using your codebase and create a Docker image with a web server to serve them. This means your final Docker image has a web server ready to serve your HTML, CSS, and JavaScript files.
 
-
-
 ## How to deploy Non-Static Website/Applications?
+
 First, follow the previous section in this documentation: [How to use Nixpacks](#how-to-use-nixpacks). After that, proceed with the steps below.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/8.webp" alt="Coolify dashboard screenshot" />
@@ -101,6 +103,7 @@ First, follow the previous section in this documentation: [How to use Nixpacks](
 1. **Branch:** Coolify will automatically detect the branch from your Repostiory.
 
 2. **Base Directory:** Enter the directory Nixpacks should use as the root (for example, `/` if your files are at the root, or a subfolder if applicable).
+
    - If you have a monorepo then you can enter the path of the directory you want to use as base directory (`/backend` for example)
 
 3. **Port:** Enter the port where your application listens for incoming requests.
@@ -111,14 +114,15 @@ First, follow the previous section in this documentation: [How to use Nixpacks](
 
 6. After clicking the **Continue** button, you can adjust settings like your domain and environment variables, then click the **Deploy** button to launch your application.
 
-
 ### How this works?
+
 Nixpacks analyzes your codebase, builds a Docker image, and then starts a container using that image.
 
-
 ## Advanced Configuration
+
 ### Environment Variables
-You can customize Nixpacks' behavior using environment variables. There are many variables available for different application frameworks, and you can find detailed information in their documentation: [Nixpacks Environment Variables](https://nixpacks.com/docs/configuration/environment?utm_source=coolify.io).  
+
+You can customize Nixpacks' behavior using environment variables. There are many variables available for different application frameworks, and you can find detailed information in their documentation: [Nixpacks Environment Variables](https://nixpacks.com/docs/configuration/environment?utm_source=coolify.io).
 
 To add or modify environment variables in Coolify, simply click on the **Environment Variables** tab, where you can manage them easily.
 
@@ -127,6 +131,7 @@ To add or modify environment variables in Coolify, simply click on the **Environ
 ---
 
 ### Commands
+
 If needed, you can override the default install, build, and start commands. Simply scroll down to the build section on Coolify and input your custom commands.
 
 <ZoomableImage src="/docs/images/builds/packs/nixpacks/10.webp" alt="Coolify dashboard screenshot" />
@@ -138,10 +143,11 @@ You may need to include a `nixpacks.toml` file in your repository for these chan
 ---
 
 ### Configuration file
+
 Nixpacks supports specifying build configurations in a nixpacks.toml or nixpacks.json file. If one of these files is present in the root of your repository, it will be automatically used. For more details, refer to the [Nixpacks documentation](https://nixpacks.com/docs/configuration/file?utm_source=coolify.io).
 
-
 ## Known issues and solutions
+
 ::: details 1. Outdated Packages/Dependencies
 Sometimes, Nixpacks may use older package versions. If you encounter this issue, update the `nixpkgs` archive version in your `nixpacks.toml` file. You can learn more about this in the Nixpacks docs on [nixpkgs archive](https://nixpacks.com/docs/configuration/file#nixpkgs-archive?utm_source=coolify.io)
 

--- a/docs/builds/packs/static.md
+++ b/docs/builds/packs/static.md
@@ -9,22 +9,21 @@ description: Deploy static websites with Nginx web server using pre-built files 
 
 Static Build Packs take the files from your project and create a Docker image with a web server to serve them. This means your final Docker image has a web server ready to display your HTML, CSS, and JavaScript files.
 
-Static Build Packs only work if your project is already built (for example, with a static site generator like [Astro ↗](https://astro.build/?utm_source=coolify.io) or [Webstudio ↗](https://webstudio.is/?utm_source=coolify.io)). Once you have the built files, you can upload them to a Git repository and use Coolify to deploy your site.
-
+Static Build Packs only work if your project is already built (for example, with a static site generator like [Astro](https://astro.build/?utm_source=coolify.io) or [Webstudio](https://webstudio.is/?utm_source=coolify.io)). Once you have the built files, you can upload them to a Git repository and use Coolify to deploy your site.
 
 ## How to Use Static Build Pack
 
 ### 1. Prepare Your Static Files
-First, build your site with your favorite static site generator. This process creates a folder with all the files your site needs (HTML, CSS, JavaScript, etc.).  
 
-Next, upload these static files to a Git repository. You can use [GitHub ↗](https://github.com/?utm_source=coolify.io), [GitLab ↗](https://about.gitlab.com/?utm_source=coolify.io), or any other Git service. For this guide, we will use [GitHub ↗](https://github.com/?utm_source=coolify.io) as an example.
+First, build your site with your favorite static site generator. This process creates a folder with all the files your site needs (HTML, CSS, JavaScript, etc.).
 
+Next, upload these static files to a Git repository. You can use [GitHub](https://github.com/?utm_source=coolify.io), [GitLab](https://about.gitlab.com/?utm_source=coolify.io), or any other Git service. For this guide, we will use [GitHub](https://github.com/?utm_source=coolify.io) as an example.
 
 ### 2. Create a New Resource in Coolify
+
 On Coolify dashboard open your project and click the **Create New Resource** button.
 
 <ZoomableImage src="/docs/images/builds/packs/static/1.webp" alt="Coolify dashboard screenshot" />
-
 
 ### 3. Choose Your Deployment Option
 
@@ -32,24 +31,24 @@ On Coolify dashboard open your project and click the **Create New Resource** but
 
 **A.** If your Git repository is public, choose the **Public Repository** option.
 
-**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App ↗](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key ↗](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
-
+**B.** If your repository is private, you can select **Github App** or **Deploy Key**. (These methods require extra configuration. You can check the guides on setting up a [Github App](/knowledge-base/git/github/integration#with-github-app-recommended) or [Deploy Key](/knowledge-base/git/github/integration#with-deploy-keys) if needed.)
 
 ### 4. Select Your Git Repository
+
 If you are using a public repository, paste the URL of your GitHub repository when prompted. The steps are very similar for all options.
 
 <ZoomableImage src="/docs/images/builds/packs/static/3.webp" alt="Coolify dashboard screenshot" />
 
-
 ### 5. Choose the Build Pack
-Coolify will default to using Nixpacks. Click on the Nixpack option, and then select **Static** from the dropdown menu.  
+
+Coolify will default to using Nixpacks. Click on the Nixpack option, and then select **Static** from the dropdown menu.
 
 <ZoomableImage src="/docs/images/builds/packs/static/4.webp" alt="Coolify dashboard screenshot" />
 
 This tells Coolify to build your image with a static web server.
 
-
 ### 6. Set the Base Directory
+
 Enter the path where your static files are located:
 
 <ZoomableImage src="/docs/images/builds/packs/static/5.webp" alt="Coolify dashboard screenshot" />
@@ -57,34 +56,33 @@ Enter the path where your static files are located:
 - If your files are in the root of your repository, just type `/`.
 - If they are in a subfolder, type the path to that folder (for example, `/out`).
 
-
 After setting the base directory, click the **Continue** button.
 
-
 ### 7. Choose a Web Server
-As of Coolify **v4.0.0-beta.402**, the only web server option available is [Nginx ↗](https://nginx.org/en/?utm_source=coolify.io). So **Nginx** will be selected by default.
+
+As of Coolify **v4.0.0-beta.402**, the only web server option available is [Nginx](https://nginx.org/en/?utm_source=coolify.io). So **Nginx** will be selected by default.
 
 <ZoomableImage src="/docs/images/builds/packs/static/6.webp" alt="Coolify dashboard screenshot" />
 
-
 ### 8. Enter Your Domain
-Type the domain name where you want your site to be available.  
+
+Type the domain name where you want your site to be available.
 
 <ZoomableImage src="/docs/images/builds/packs/static/7.webp" alt="Coolify dashboard screenshot" />
 
 If you have multiple domains, separate them with commas.
 
-
 ### 9. Deploy Your Site
+
 Click the **Deploy** button. The deployment process is usually quick (often less than a minute, depending on your server).
 
 <ZoomableImage src="/docs/images/builds/packs/static/8.webp" alt="Coolify dashboard screenshot" />
 
 Once the deployment is finished, visit your domain in a browser to see your live site.
 
-
 ### 10. Customize Your Web Server Configuration <Badge type="warning" text="Optional" />
-Coolify provides a default web server configuration that works for most cases. 
+
+Coolify provides a default web server configuration that works for most cases.
 
 If you want to change it then click the **Generate** button to load the default settings and make any changes you need.
 

--- a/docs/databases/clickhouse.md
+++ b/docs/databases/clickhouse.md
@@ -3,82 +3,84 @@ title: ClickHouse
 description: Deploy ClickHouse on Coolify with column-oriented OLAP database, real-time analytics, S3 backups, and exceptional query performance.
 ---
 
-
 # Clickhouse
 
  <ZoomableImage src="/docs/images/database-logos/clickhouse.webp" alt="Coolify clickhouse" />
 
-
 ## What is ClickHouse
-ClickHouse is an open-source column-oriented database management system designed for online analytical processing (OLAP). 
+
+ClickHouse is an open-source column-oriented database management system designed for online analytical processing (OLAP).
 
 It's known for its exceptional query performance on large datasets, making it ideal for real-time analytics and data warehousing applications.
 
-ClickHouse uses a column-oriented storage format and employs various optimizations like vectorized query execution to achieve high performance. 
+ClickHouse uses a column-oriented storage format and employs various optimizations like vectorized query execution to achieve high performance.
 
 It supports SQL with extensions and can handle both batch and stream data ingestion, making it versatile for various analytical workloads.
 
-
 ## Backup and Restore Guide
+
 Currently, Coolify does not support modifying ClickHouse configurations, which means certain native backup options (e.g., backing up to a local Disk or using `ALTER TABLE ... FREEZE PARTITION ...`) are not possible. Instead, the recommended approach is to use S3 for backups.
 
-
 ### How to Backup ClickHouse
+
 To backup a table or an entire database, use the following SQL command:
 
 - **Backup a Table:**
+
 ```sql
 BACKUP TABLE <table_name> TO S3('<your_s3_endpoint_com>/<unique_folder_for_table_backup>', '<s3_access_key>', '<s3_secret_key>')
 ```
 
 - **Backup a Database:**
-Replace `TABLE` with `DATABASE` to backup the whole database:
+  Replace `TABLE` with `DATABASE` to backup the whole database:
 
 ```sql
 BACKUP DATABASE <database_name> TO S3('<your_s3_endpoint_com>/<unique_folder_for_database_backup>', '<s3_access_key>', '<s3_secret_key>')
 ```
 
-
 ### How to Restore ClickHouse
+
 To restore a table or database from an S3 backup, use the corresponding RESTORE command:
 
 - **Restore a Table:**
+
 ```sql
 RESTORE TABLE <table_name> FROM S3('<your_s3_endpoint_com>/<unique_folder_from_table_backup>', '<s3_access_key>', '<s3_secret_key>')
 ```
 
 - **Restore a Database:**
-Replace `TABLE` with `DATABASE` to restore the whole database:
+  Replace `TABLE` with `DATABASE` to restore the whole database:
 
 ```sql
 RESTORE DATABASE <database_name> FROM S3('<your_s3_endpoint_com>/<unique_folder_from_database_backup>', '<s3_access_key>', '<s3_secret_key>')
 ```
 
-
 ### What Doesn't Work
+
 - **Disk Backups:**
 
 ```sql
 BACKUP TABLE test.table TO Disk('backups', '1.zip')
 ```
+
 Does not work due to Coolify not allowing modifications to ClickHouse configurations.
 
-- **Native Partition Freezes:** 
+- **Native Partition Freezes:**
 
 ```sql
 ALTER TABLE ... FREEZE PARTITION ...
 ```
+
 May not work because of limitations in the Docker/Coolify file structure.
 
 - **clickhouse-backup Tool:**
-External tools like [clickhouse-backup](https://github.com/Altinity/clickhouse-backup?utm_source=coolify.io) might not function properly within the Docker/Coolify setup due to similar configuration restrictions.
-
+  External tools like [clickhouse-backup](https://github.com/Altinity/clickhouse-backup?utm_source=coolify.io) might not function properly within the Docker/Coolify setup due to similar configuration restrictions.
 
 ### Performance Notes
-A community member shared that backing up a 145GB database took around 12 minutes, while restoring it took roughly 17 minutes.
 
+A community member shared that backing up a 145GB database took around 12 minutes, while restoring it took roughly 17 minutes.
 
 ## Links
 
-- [The official website ›](https://clickhouse.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/ClickHouse/ClickHouse?utm_source=coolify.io)
+- [The official website](https://clickhouse.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/ClickHouse/ClickHouse?utm_source=coolify.io)

--- a/docs/databases/dragonfly.md
+++ b/docs/databases/dragonfly.md
@@ -14,19 +14,20 @@ DragonFly is a modern in-memory datastore, designed as a Redis alternative with 
 With its multi-threaded architecture and advanced data structures, DragonFly aims to provide enhanced scalability and performance for applications that require Redis-like functionality on modern hardware.
 
 ## Data Persistence
-By default, Dragonfly DB does not save data to disk. To enable persistence, set up snapshots manually. 
+
+By default, Dragonfly DB does not save data to disk. To enable persistence, set up snapshots manually.
 
 For example, configure the service with:
 
- ```yaml
+```yaml
 services:
   dragonfly:
     command: 'dragonfly --requirepass XXXXXXXX --dir /data --dbfilename dragonfly-snapshot-{timestamp} --snapshot_cron "*/5 * * * *"'
- ```
+```
 
 You can also trigger manual saves using the SDK's `SAVE` command.
 
 ## Links
 
-- [The official website ›](https://dragonflydb.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/dragonflydb/dragonfly?utm_source=coolify.io)
+- [The official website](https://dragonflydb.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/dragonflydb/dragonfly?utm_source=coolify.io)

--- a/docs/databases/keydb.md
+++ b/docs/databases/keydb.md
@@ -4,6 +4,7 @@ description: Deploy KeyDB on Coolify with high-performance multithreading, Redis
 ---
 
 # KeyDB
+
 <!-- Commentented out the image because it is taking up the whole screen, will be fixed later -->
 <!-- ![KeyDB](/images/database-logos/keydb.webp) -->
 
@@ -15,5 +16,5 @@ Designed to be a drop-in replacement for Redis, KeyDB aims to provide better res
 
 ## Links
 
-- [The official website ›](https://keydb.dev/)
-- [GitHub ›](https://github.com/EQ-Alpha/KeyDB)
+- [The official website](https://keydb.dev/)
+- [GitHub](https://github.com/EQ-Alpha/KeyDB)

--- a/docs/databases/mariadb.md
+++ b/docs/databases/mariadb.md
@@ -16,5 +16,5 @@ Started by core members of MySQL, MariaDB provides a robust and scalable databas
 
 ## Links
 
-- [The official website ›](https://mariadb.org/)
-- [GitHub ›](https://github.com/MariaDB/server)
+- [The official website](https://mariadb.org/)
+- [GitHub](https://github.com/MariaDB/server)

--- a/docs/databases/mongodb.md
+++ b/docs/databases/mongodb.md
@@ -15,5 +15,5 @@ MongoDB is known for its horizontal scalability, powerful query language, and ab
 
 ## Links
 
-- [The official website ›](https://www.mongodb.com/)
-- [GitHub ›](https://github.com/mongodb/mongo)
+- [The official website](https://www.mongodb.com/)
+- [GitHub](https://github.com/mongodb/mongo)

--- a/docs/databases/mysql.md
+++ b/docs/databases/mysql.md
@@ -15,5 +15,5 @@ MySQL provides a robust, ACID-compliant database solution suitable for a wide ra
 
 ## Links
 
-- [The official website ›](https://www.mysql.com/)
-- [GitHub ›](https://github.com/mysql/mysql-server)
+- [The official website](https://www.mysql.com/)
+- [GitHub](https://github.com/mysql/mysql-server)

--- a/docs/databases/postgresql.md
+++ b/docs/databases/postgresql.md
@@ -15,8 +15,8 @@ PostgreSQL, often simply "Postgres", uses and extends the SQL language combined 
 
 ## Links
 
-- [The official website ›](https://www.postgresql.org/)
-- [GitHub ›](https://github.com/postgres/postgres)
+- [The official website](https://www.postgresql.org/)
+- [GitHub](https://github.com/postgres/postgres)
 
 ## Import Backups
 
@@ -40,10 +40,10 @@ docker exec pg-db pg_dump -U postgres -d postgres -Fc >example-database.sql.gz
 
 ### Note on upgrading PostgreSQL
 
-The __custom__ dump format is sensitive to version differences between the dump and
+The **custom** dump format is sensitive to version differences between the dump and
 restore commands.
 
-Use the plain (default) or __tar__ dump formats to migrate from an older version
+Use the plain (default) or **tar** dump formats to migrate from an older version
 of PostgreSQL to a newer version. When using plain format dumps, use `psql` as
 the custom import command instead of `pg_restore`.
 

--- a/docs/databases/redis.md
+++ b/docs/databases/redis.md
@@ -13,5 +13,5 @@ Redis is an in-memory data store used by millions of developers as a cache, vect
 
 ## Links
 
-- [The official website ›](https://redis.io/)
-- [GitHub ›](https://github.com/redis/redis)
+- [The official website](https://redis.io/)
+- [GitHub](https://github.com/redis/redis)

--- a/docs/get-started/cloud.md
+++ b/docs/get-started/cloud.md
@@ -7,171 +7,176 @@ description: Coolify Cloud is a fully managed PaaS service with zero maintenance
 
 <br />
 
+[Coolify Cloud](https://coolify.io/pricing/) is our managed, paid service (maintained by [Andras](https://x.com/heyandras), Coolify’s Founder) that runs the Coolify on our infrastructure, so you don’t need to allocate CPU, RAM, or disk for Coolify itself.
 
-[Coolify Cloud](https://coolify.io/pricing/) is our managed, paid service (maintained by [Andras](https://x.com/heyandras), Coolify’s Founder) that runs the Coolify on our infrastructure, so you don’t need to allocate CPU, RAM, or disk for Coolify itself. 
-
-You still bring your own servers (VPS, Raspberry Pi, EC2, etc.) and connect them via SSH, then deploy apps, databases, and services exactly as you would with a self-hosted instance. 
+You still bring your own servers (VPS, Raspberry Pi, EC2, etc.) and connect them via SSH, then deploy apps, databases, and services exactly as you would with a self-hosted instance.
 
 Coolify Cloud uses the same open-source codebase, so there are no locked-behind-paywall features.
 
-
 ## Benefits of Coolify Cloud
-| Features                    | Explanation                                                                                                          |
-| :-------------------------- | :------------------------------------------------------------------------------------------------------------------- |
-| **Zero Maintenance Coolify**   | No need to upgrade, or monitor Coolify, our team does it for you.                     |
-| **Daily Backups**           | The Coolify Cloud database is backed up every 24 hours. |
-| **Preconfigured Email**     | Receive build, deployment, and server status notifications via email without any setup on your end.                              |
-| **Automatic Scaling**       | As you connect more servers, our infrastructure scales CPU, RAM, and disk usage for Coolify.                         |
-| **Staged Updates**          | New updates are first rolled out to self-hosted users. Once stability is confirmed, they’re rolled out to Cloud.             |
-| **Founder-Tested Releases** | Andras personally tests every update before it’s deployed to the Cloud, ensuring maximum stability and reliability.                         |
 
+| Features                     | Explanation                                                                                                         |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| **Zero Maintenance Coolify** | No need to upgrade, or monitor Coolify, our team does it for you.                                                   |
+| **Daily Backups**            | The Coolify Cloud database is backed up every 24 hours.                                                             |
+| **Preconfigured Email**      | Receive build, deployment, and server status notifications via email without any setup on your end.                 |
+| **Automatic Scaling**        | As you connect more servers, our infrastructure scales CPU, RAM, and disk usage for Coolify.                        |
+| **Staged Updates**           | New updates are first rolled out to self-hosted users. Once stability is confirmed, they’re rolled out to Cloud.    |
+| **Founder-Tested Releases**  | Andras personally tests every update before it’s deployed to the Cloud, ensuring maximum stability and reliability. |
 
 ## Getting Started with Coolify Cloud
-1. **Create Your Account:**    
-   * Visit the [Coolify Cloud Registration ↗](https://app.coolify.io/register) page and sign up.
+
+1. **Create Your Account:**
+
+   - Visit the [Coolify Cloud Registration](https://app.coolify.io/register) page and sign up.
 
 2. **Choose Your Plan:**
-   * Base fee: **$5/month** (includes up to two connected servers).
-   * **$3/month** per additional server.
+
+   - Base fee: **$5/month** (includes up to two connected servers).
+   - **$3/month** per additional server.
 
 3. **Complete Payment**
-   * Use any major credit/debit card to finish the subscription process.
+
+   - Use any major credit/debit card to finish the subscription process.
 
 4. **Connect Your Servers**
-   * ::: details Detailed Server Connection Guide
-      1. **Add Private Key:** Login to your Coolify account (or create one if you’re new) and Add a new private key
-          <ZoomableImage src="/docs/images/resources/integrations/6.webp" alt="Coolify dashboard screenshot" />
-          <br />
-          <ZoomableImage src="/docs/images/resources/integrations/7.webp" alt="Coolify dashboard screenshot" />
-      ---
-      2. **Add a Server:** Navigate to the **Servers** tab and add a new server by entering your Hetzner server’s IPv4 address.
-          <ZoomableImage src="/docs/images/resources/integrations/8.webp" alt="Coolify dashboard screenshot" />
-          <br />
-          <ZoomableImage src="/docs/images/resources/integrations/9.webp" alt="Coolify dashboard screenshot" />
-      ---
-      3. **Validate Server:** Click **Validate Server & Install Docker Engine**. Coolify will automatically install all necessary components on your server.
-          <ZoomableImage src="/docs/images/resources/integrations/10.webp" alt="Coolify dashboard screenshot" />
-      ---
-      4. **Check Status:** Once finished, you should see a green **Proxy Running** status indicating everything is set up.
-          <ZoomableImage src="/docs/images/resources/integrations/11.webp" alt="Coolify dashboard screenshot" />
-      :::
+
+   - ::: details Detailed Server Connection Guide
+     1. **Add Private Key:** Login to your Coolify account (or create one if you’re new) and Add a new private key
+        <ZoomableImage src="/docs/images/resources/integrations/6.webp" alt="Coolify dashboard screenshot" />
+        <br />
+        <ZoomableImage src="/docs/images/resources/integrations/7.webp" alt="Coolify dashboard screenshot" />
+     ***
+     2. **Add a Server:** Navigate to the **Servers** tab and add a new server by entering your Hetzner server’s IPv4 address.
+        <ZoomableImage src="/docs/images/resources/integrations/8.webp" alt="Coolify dashboard screenshot" />
+        <br />
+        <ZoomableImage src="/docs/images/resources/integrations/9.webp" alt="Coolify dashboard screenshot" />
+     ***
+     3. **Validate Server:** Click **Validate Server & Install Docker Engine**. Coolify will automatically install all necessary components on your server.
+        <ZoomableImage src="/docs/images/resources/integrations/10.webp" alt="Coolify dashboard screenshot" />
+     ***
+     4. **Check Status:** Once finished, you should see a green **Proxy Running** status indicating everything is set up.
+        <ZoomableImage src="/docs/images/resources/integrations/11.webp" alt="Coolify dashboard screenshot" />
+        :::
 
 5. **Deploy Your Applications**
 
-
 ## How Coolify Cloud Pricing works?
-We charge a base fee of **\$5/month**, which covers up to **two servers**. Each additional server you connect is an **add-on of \$3/month**. 
+
+We charge a base fee of **\$5/month**, which covers up to **two servers**. Each additional server you connect is an **add-on of \$3/month**.
 
 Charging per server allows us to scale our infrastructure responsibly, since each connected server increases resource usage (CPU, RAM, storage) on our end.
 
-If you only need one server, you still pay the $5 base fee (with capacity for a second server if you add it later). 
+If you only need one server, you still pay the $5 base fee (with capacity for a second server if you add it later).
 
 If you plan to connect more than two, simply multiply $3 by the extra servers.
 
-
 ## Why Coolify Cloud Exists
-You might wonder why Coolify Cloud is a paid service when there are no exclusive, locked-down features. 
+
+You might wonder why Coolify Cloud is a paid service when there are no exclusive, locked-down features.
 
 The idea came to Andras (Coolify's Founder) as a way to offer a “**paid option without paywall**” — a model where the open-source project stays completely free, but those who prefer a managed experience can contribute financially.
 
 - **Experiment Turned Success:**
-   * Initially launched as an experiment, Coolify Cloud quickly attracted over 2,100 active users.
+  - Initially launched as an experiment, Coolify Cloud quickly attracted over 2,100 active users.
 
 * **Sustainable Funding:**
-   * While the revenue from Cloud is modest, it provides a steady income stream that helps keep Coolify free and under active development for everyone.
+
+  - While the revenue from Cloud is modest, it provides a steady income stream that helps keep Coolify free and under active development for everyone.
 
 * **Community-First Approach**
-   * By not restricting any features, we maintain transparency and trust. 
-   * Cloud subscribers simply pay for convenience and reliability, not to unlock core functionality.
+  - By not restricting any features, we maintain transparency and trust.
+  - Cloud subscribers simply pay for convenience and reliability, not to unlock core functionality.
 
 ## Frequently Asked Questions
+
 ::: details 1. Do I get any Cloud-only features?
-  No. Coolify Cloud and self-hosted Coolify share the same feature set. 
-  
-  Cloud’s value lies in automatic backups, email notifications, scaling, and update testing handled for you.
+No. Coolify Cloud and self-hosted Coolify share the same feature set.
+
+Cloud’s value lies in automatic backups, email notifications, scaling, and update testing handled for you.
 :::
 ::: details 2. Does Coolify Cloud back up my application data?
-  No, Coolify Cloud only backs up the Coolify database (e.g., dashboard settings). 
+No, Coolify Cloud only backs up the Coolify database (e.g., dashboard settings).
 
-  You are responsible for backing up any databases or storage volumes on your servers.
+You are responsible for backing up any databases or storage volumes on your servers.
 :::
 ::: details 3. Can I import my self-hosted Coolify configurations to Coolify Cloud?
-  No. 
-  
-  To transfer configurations, you'll need to back up the database from your self-hosted instance and restore it to a new Coolify instance. 
-  
-  However, since you don’t have access to the database in Coolify Cloud, it’s not possible to migrate data or settings directly to the cloud version.
+No.
+
+To transfer configurations, you'll need to back up the database from your self-hosted instance and restore it to a new Coolify instance.
+
+However, since you don’t have access to the database in Coolify Cloud, it’s not possible to migrate data or settings directly to the cloud version.
 :::
 ::: details 4. How often Coolify Cloud is backed up?
-  Every 24 hours
+Every 24 hours
 :::
 ::: details 5. Is Coolify Cloud really based on the open-source version of Coolify?
-  Yes, Coolify Cloud uses the same open-source codebase as the self-hosted version. There are no paywall features, and the Cloud service is simply a managed experience for convenience.
+Yes, Coolify Cloud uses the same open-source codebase as the self-hosted version. There are no paywall features, and the Cloud service is simply a managed experience for convenience.
 :::
 ::: details 6. What happens if I cancel my Coolify Cloud subscription?
-  If you cancel your subscription, you will stop being billed, and your access to Coolify Cloud will be suspended at the end of your current billing cycle.
-  
-  However, your servers will remain unaffected, and all of your applications will continue running as normal. 
-  
-  Since your server will still be hosting your applications with a reverse proxy handling incoming requests, there will be no interruptions.
+If you cancel your subscription, you will stop being billed, and your access to Coolify Cloud will be suspended at the end of your current billing cycle.
+
+However, your servers will remain unaffected, and all of your applications will continue running as normal.
+
+Since your server will still be hosting your applications with a reverse proxy handling incoming requests, there will be no interruptions.
 :::
 ::: details 7. What happens if I forget to pay an invoice?
-  If a payment fails or an invoice is missed, your subscription and access to Coolify Cloud will be temporarily paused until the payment is successfully processed. 
-  
-  You will receive an email notification about the failed payment. 
-  
-  Once the payment is made, your Coolify Cloud access will be restored, and all your settings will remain intact—there’s no data loss. 
-  
-  Your servers will also stay up and running, and your applications will continue to function normally, as everything is still hosted on your own server with a reverse proxy.
+If a payment fails or an invoice is missed, your subscription and access to Coolify Cloud will be temporarily paused until the payment is successfully processed.
+
+You will receive an email notification about the failed payment.
+
+Once the payment is made, your Coolify Cloud access will be restored, and all your settings will remain intact—there’s no data loss.
+
+Your servers will also stay up and running, and your applications will continue to function normally, as everything is still hosted on your own server with a reverse proxy.
 :::
 
 ::: details 8. Are there any IP addresses I need to whitelist for Coolify Cloud?
-  Yes, Coolify Cloud uses specific IP addresses. 
-  
-  You can find the list of IPs [here](https://coolify.io/docs/knowledge-base/faq#coolify-cloud-public-ips). 
-  
-  The main requirement is that Coolify Cloud needs to access your server's SSH port.
+Yes, Coolify Cloud uses specific IP addresses.
+
+You can find the list of IPs [here](https://coolify.io/docs/knowledge-base/faq#coolify-cloud-public-ips).
+
+The main requirement is that Coolify Cloud needs to access your server's SSH port.
 :::
 ::: details 9. Do I need to bring my own servers to Coolify Cloud?
-  Yes, when using Coolify Cloud, you must provide your own servers (e.g., VPS, Raspberry Pi, EC2, etc.). 
-  
-  Coolify Cloud manages Coolify on our infrastructure, but we don’t provide the servers themselves. 
-  
-  This approach allows you to choose the hardware that best fits your needs.
+Yes, when using Coolify Cloud, you must provide your own servers (e.g., VPS, Raspberry Pi, EC2, etc.).
+
+Coolify Cloud manages Coolify on our infrastructure, but we don’t provide the servers themselves.
+
+This approach allows you to choose the hardware that best fits your needs.
 :::
 ::: details 10. Why do I have to pay for Coolify Cloud if I’m bringing my own servers?
-  While you bring your own servers, the subscription fee for Coolify Cloud covers the managed service aspect. 
-  
-  This includes infrastructure management, maintenance, support, updates, and scaling, so you don’t have to worry about technical aspects like monitoring, patching, or backups for Coolify. 
-  
-  We take care of the heavy lifting to ensure everything runs smoothly.
+While you bring your own servers, the subscription fee for Coolify Cloud covers the managed service aspect.
+
+This includes infrastructure management, maintenance, support, updates, and scaling, so you don’t have to worry about technical aspects like monitoring, patching, or backups for Coolify.
+
+We take care of the heavy lifting to ensure everything runs smoothly.
 :::
 ::: details 11. What happens if I exceed the number of connected servers?
-  You won’t be able to add extra servers to Coolify cloud unless your subscription is upgraded.
+You won’t be able to add extra servers to Coolify cloud unless your subscription is upgraded.
 :::
 ::: details 12. Is there a trial period for Coolify Cloud?
-  Currently, Coolify Cloud doesn’t offer a free trial. However, the subscription is affordable—just **$5 per month** for up to two connected servers. 
-  
-  If you want to explore all the features, you can run Coolify on a small Linux server or a VM on your PC by following the [self-hosted installation guide](https://coolify.io/docs/get-started/installation). 
-  
-  Since both cloud and self-hosted versions use the same codebase, you’ll be able to test all the features without any limitations.
+Currently, Coolify Cloud doesn’t offer a free trial. However, the subscription is affordable—just **$5 per month** for up to two connected servers.
+
+If you want to explore all the features, you can run Coolify on a small Linux server or a VM on your PC by following the [self-hosted installation guide](https://coolify.io/docs/get-started/installation).
+
+Since both cloud and self-hosted versions use the same codebase, you’ll be able to test all the features without any limitations.
 :::
 ::: details 13. Can I get any discounts?
-  The current **$5/month** subscription rate is already quite affordable, so discounts are not available at the moment.
+The current **$5/month** subscription rate is already quite affordable, so discounts are not available at the moment.
 :::
 ::: details 14. I have to pay to use Coolify Cloud, so doesn't that mean I'm locked into a vendor?
-  **Not really.**
-  
-  You're paying for the managed Coolify instance, but stopping the use of Coolify Cloud won't affect your applications. 
-  
-  You can connect your own server, so you retain full control. Everything runs as a Docker container, and Coolify will install a reverse proxy on your server to ensure everything works smoothly without needing Coolify Cloud. 
-  
-  In a true vendor lock-in, your apps would stop if you stop paying, but that’s not the case with Coolify Cloud.
+**Not really.**
+
+You're paying for the managed Coolify instance, but stopping the use of Coolify Cloud won't affect your applications.
+
+You can connect your own server, so you retain full control. Everything runs as a Docker container, and Coolify will install a reverse proxy on your server to ensure everything works smoothly without needing Coolify Cloud.
+
+In a true vendor lock-in, your apps would stop if you stop paying, but that’s not the case with Coolify Cloud.
 :::
 ::: details 15. Can I access the Coolify Cloud dashboard on my own domain?
-  No. 
-  
-  The Coolify Cloud dashboard is only available at https://app.coolify.io. 
-  
-  If you’d like to access the dashboard on your own domain, you’ll need to self-host Coolify.
+No.
+
+The Coolify Cloud dashboard is only available at https://app.coolify.io.
+
+If you’d like to access the dashboard on your own domain, you’ll need to self-host Coolify.
 :::

--- a/docs/get-started/concepts.md
+++ b/docs/get-started/concepts.md
@@ -63,7 +63,7 @@ This setup lets you run multiple applications on one server without tweaking con
 
 Plus, Coolify supports unlimited domains, so you could deploy 20 different apps, each with its own unique domain.
 
-The reverse proxy also automatically manages SSL/TLS certificates for your applications. When you enter a domain with `https://`, the proxy requests and installs certificates from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) automatically, with no manual configuration needed. Certificates are renewed automatically before they expire, keeping your applications secure without any intervention.
+The reverse proxy also automatically manages SSL/TLS certificates for your applications. When you enter a domain with `https://`, the proxy requests and installs certificates from [Let's Encrypt](https://letsencrypt.org?utm_source=coolify.io) automatically, with no manual configuration needed. Certificates are renewed automatically before they expire, keeping your applications secure without any intervention.
 
 ## Security
 

--- a/docs/get-started/contribute/service.md
+++ b/docs/get-started/contribute/service.md
@@ -130,8 +130,8 @@ As soon as you have your local setup ready, follow these steps to add your new s
 
    ## Links
 
-   - [Official website ↗](https://example.com?utm_source=coolify.io)
-   - [GitHub ↗](https://github.com/example/repo?utm_source=coolify.io)
+   - [Official website](https://example.com?utm_source=coolify.io)
+   - [GitHub](https://github.com/example/repo?utm_source=coolify.io)
    ```
 
 4. Add Service to the Services Overview

--- a/docs/get-started/downgrade.md
+++ b/docs/get-started/downgrade.md
@@ -7,25 +7,23 @@ description: Downgrade self-hosted Coolify to previous versions by disabling aut
 
 <br />
 
-If you're using [Coolify Cloud ↗](https://coolify.io/pricing/), the Coolify team handles all updates so you  **cannot** downgrade the version of Coolify. If you are facing any issues, please contact [support ↗](/get-started/support). 
-
+If you're using [Coolify Cloud](https://coolify.io/pricing/), the Coolify team handles all updates so you **cannot** downgrade the version of Coolify. If you are facing any issues, please contact [support](/get-started/support).
 
 For those who **self-host** Coolify, you can easily downgrade to the previous version. Follow the steps below to perform a downgrade on to a previous version.
 
-:::danger **Backup First!**  
-  > **Always back up your Coolify data before performing an downgrade.**
-  > **Downgrading can introduce issues that can be difficult to fix.**
-:::
+:::danger **Backup First!**
 
-
+> **Always back up your Coolify data before performing an downgrade.** > **Downgrading can introduce issues that can be difficult to fix.**
+> :::
 
 The Downgrade process involves the following three steps:
+
 - [Disable Auto Update](#_1-disable-auto-update)
 - [Login to Your Server via SSH](#_2-login-to-your-server-via-ssh)
 - [Execute the Downgrade Command](#_3-execute-the-downgrade-command)
 
-
 ## 1. Disable Auto Update
+
 Before downgrading, it's important to disable the Auto Update feature to prevent Coolify from automatically upgrading again after you perform the downgrade.
 
 1. Log in as the root user (or any user who has access to the root or initial team).
@@ -37,37 +35,42 @@ Before downgrading, it's important to disable the Auto Update feature to prevent
 <ZoomableImage src="/docs/images/get-started/upgrade/disable-auto-update.webp" alt="Disable Auto Update" />
 
 ::: warning Important!
-  Disabling auto-update is essential, as it ensures that Coolify doesn’t override your downgrade with a newer version.
+Disabling auto-update is essential, as it ensures that Coolify doesn’t override your downgrade with a newer version.
 :::
 
-
 ## 2. Login to Your Server via SSH
+
 Next, you need to SSH into your server to execute the downgrade command.
 
-
 ## 3. Execute the Downgrade Command
+
 To downgrade Coolify to the desired version, run the following command in your terminal:
+
 ```sh
 curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.0.0-beta.369
 ```
-Replace `4.0.0-beta.369` with the version number you want to downgrade to. 
+
+Replace `4.0.0-beta.369` with the version number you want to downgrade to.
 
 For example, you can downgrade to `4.0.0-beta.333` or any previous version.
 
 ::: warning Note
-  Double-check the version number you are specifying to ensure you are downgrading to the correct version. You can check the Coolify [release notes ↗](https://github.com/coollabsio/coolify/releases) for version details.
+Double-check the version number you are specifying to ensure you are downgrading to the correct version. You can check the Coolify [release notes](https://github.com/coollabsio/coolify/releases) for version details.
 :::
 
-
 ## Potential Issues with Downgrading
+
 While downgrading is possible, be aware of the following risks:
+
 - [Database Schema Compatibility](#database-schema-compatibility)
 - [Feature Incompatibility](#feature-incompatibility)
 
 ---
 
-#### Database Schema Compatibility: 
+#### Database Schema Compatibility:
+
 Downgrading can cause issues since the database schema may not be backward compatible. Some features may not work as expected due to changes in the database structure between versions.
 
-#### Feature Incompatibility: 
+#### Feature Incompatibility:
+
 Some features might not function properly after downgrading, as certain features in the newer version may rely on changes that are not present in the older version.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -8,20 +8,22 @@ outline: 2
 
 <br />
 
-If you decide to go with **Coolify Cloud**, there's no installation required. Simply visit [Coolify Cloud Registration ↗](https://app.coolify.io/register) to create an account and start using Coolify within minutes!
+If you decide to go with **Coolify Cloud**, there's no installation required. Simply visit [Coolify Cloud Registration](https://app.coolify.io/register) to create an account and start using Coolify within minutes!
 
 Below, you'll find instructions for installing Coolify if you prefer to **self-host** it.
 
 ## Self-hosted Installation
 
-If you like taking control and managing everything yourself, self-hosting Coolify is the way to go. 
+If you like taking control and managing everything yourself, self-hosting Coolify is the way to go.
 
 It's completely free (apart from your server costs) and gives you full control over your setup.
 
 ::: success ⚡️ Quick Installation (recommended):
+
 ```sh
 curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
 ```
+
 Run this script in your terminal, and Coolify will be installed automatically. For more details, including firewall configuration and prerequisites, check out the guide below.
 
 :::
@@ -29,16 +31,19 @@ Run this script in your terminal, and Coolify will be installed automatically. F
 ::: warning Note for Ubuntu Users:
 The automatic installation script only works with Ubuntu LTS versions (20.04, 22.04, 24.04). If you're using a non-LTS version (e.g., 24.10), please use the [Manual Installation](#manual-installation) method below.
 :::
+
 ## Before You Begin
 
 Before installing Coolify, make sure your server meets the necessary requirements.
 
 ### 1. Server Requirements
+
 You need a server with SSH access. This could be:
+
 - A VPS (Virtual Private Server)
 - A Dedicated Server
 - A Virtual Machine (VM)
-- A Raspberry Pi (see our [Raspberry Pi OS Setup Guide ↗](/knowledge-base/how-to/raspberry-pi-os#prerequisites))
+- A Raspberry Pi (see our [Raspberry Pi OS Setup Guide](/knowledge-base/how-to/raspberry-pi-os#prerequisites))
 - Or any other server with SSH access
 
 :::warning Note:
@@ -46,11 +51,13 @@ It’s best to use a fresh server for Coolify to avoid any conflicts with existi
 :::
 
 :::info Tip:
-If you haven't picked a server provider yet, consider using [Hetzner ↗](https://coolify.io/hetzner). You can even use our [referral link ↗](https://coolify.io/hetzner) to support the project.
+If you haven't picked a server provider yet, consider using [Hetzner](https://coolify.io/hetzner). You can even use our [referral link](https://coolify.io/hetzner) to support the project.
 :::
 
 ### 2. Supported Operating Systems
+
 Coolify supports several Linux distributions:
+
 - Debian-based (e.g., Debian, Ubuntu - all versions supported, but non-LTS Ubuntu requires manual installation)
 - Redhat-based (e.g., CentOS, Fedora, Redhat, AlmaLinux, Rocky, Asahi)
 - SUSE-based (e.g., SLES, SUSE, openSUSE)
@@ -59,46 +66,53 @@ Coolify supports several Linux distributions:
 - Raspberry Pi OS 64-bit (Raspbian)
 
 ::: info Note
-For some distros (like AlmaLinux), Docker must be pre-installed. If the install script fails, manually install Docker and re-run the script. 
+For some distros (like AlmaLinux), Docker must be pre-installed. If the install script fails, manually install Docker and re-run the script.
 
 Other Linux distributions may work with Coolify, but have not been officially tested.
 :::
 
 ### 3. Supported Architectures
+
 Coolify runs on 64-bit systems:
+
 - AMD64
 - ARM64
 
 ::: warning ⚠️ Note for Raspberry Pi users:
-Be sure to use the 64-bit version of Raspberry Pi OS (Raspbian). For details, check our [Raspberry Pi OS Setup Guide ↗](/knowledge-base/how-to/raspberry-pi-os#prerequisites).
+Be sure to use the 64-bit version of Raspberry Pi OS (Raspbian). For details, check our [Raspberry Pi OS Setup Guide](/knowledge-base/how-to/raspberry-pi-os#prerequisites).
 :::
 
 ### 4. Minimum Hardware Requirements
+
 Your server should have at least:
+
 - **CPU**: 2 cores
 - **Memory (RAM)**: 2 GB
 - **Storage**: 30 GB of free space
 
-Coolify may function properly on servers with lower specs than those mentioned above, but we recommend slightly higher minimum requirements. 
+Coolify may function properly on servers with lower specs than those mentioned above, but we recommend slightly higher minimum requirements.
 
 This ensures that users have sufficient resources to deploy multiple applications without performance issues.
 
 ::: warning Heads up!
-If you’re running both builds and Coolify on the same server, monitor your resource usage. High resource usage could make your server unresponsive. 
+If you’re running both builds and Coolify on the same server, monitor your resource usage. High resource usage could make your server unresponsive.
 
 Consider enabling swap space or upgrading your server if needed.
 :::
 
 ### 5. Server Resources for Your Projects
+
 The resources you need depend on your projects. For example, if you're hosting multiple services or larger applications, choose a server with higher CPU, memory, and storage.
 
 ::: success ⚙️ Example Setup:
 Andras runs his production apps on a server with:
+
 - **Memory**: 8GB (average usage: 3.5GB)
 - **CPU**: 4 cores (average usage: 20–30%)
 - **Storage**: 150GB (average usage: 40GB)
 
 This setup comfortably supports:
+
 - 3 NodeJS apps
 - 4 Static sites
 - Plausible Analytics
@@ -107,13 +121,14 @@ This setup comfortably supports:
 - Ghost (newsletters)
 - 3 Redis databases
 - 2 PostgreSQL databases
-:::
+  :::
 
 ## Installation Methods
 
 There are two ways to install Coolify:
-- [Quick Installation ↗](#quick-installation-recommended) (Recommended)
-- [Manual Installation ↗](#manual-installation)
+
+- [Quick Installation](#quick-installation-recommended) (Recommended)
+- [Manual Installation](#manual-installation)
 
 We highly recommend the **Quick Installation** method as it automates the process and reduces the chance of errors.
 
@@ -124,35 +139,40 @@ We highly recommend the **Quick Installation** method as it automates the proces
 This is the simplest and fastest way to get Coolify up and running.
 
 #### 1. Prepare Your Server
+
 - Log in as the root user (non-root users are not fully supported yet).
-- Configure SSH by following the [SSH Settings Guide ↗](/knowledge-base/server/openssh#ssh-settings-configuration).
-- Set up your firewall with the help of the [Firewall Guide ↗](/knowledge-base/server/firewall).
-- Ensure that [curl ↗](https://curl.se/) is installed (it usually comes pre-installed).
+- Configure SSH by following the [SSH Settings Guide](/knowledge-base/server/openssh#ssh-settings-configuration).
+- Set up your firewall with the help of the [Firewall Guide](/knowledge-base/server/firewall).
+- Ensure that [curl](https://curl.se/) is installed (it usually comes pre-installed).
 
 #### 2. Run the Installation Script
+
 Once your server is ready, run:
+
 ```sh
 curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
 ```
 
-View the [Script's Source Code ↗](https://github.com/coollabsio/coolify/blob/main/scripts/install.sh)
+View the [Script's Source Code](https://github.com/coollabsio/coolify/blob/main/scripts/install.sh)
 
-::: info Tip: 
-  If you're not logged in as the root user, run the script with sudo:
+::: info Tip:
+If you're not logged in as the root user, run the script with sudo:
 
-  ```sh
-  curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
-  ```
-  You can also set up the first admin account directly during the installation. For details, see: [Create Root User with Environment Variables ↗](/knowledge-base/create-root-user-with-env)
+```sh
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
+```
+
+You can also set up the first admin account directly during the installation. For details, see: [Create Root User with Environment Variables](/knowledge-base/create-root-user-with-env)
 :::
 
 There are several environment variables that you can set to customize your Coolify installation.
 
 For example, you can setup a default root user or define the default docker network pool.
 
-See the [Define Custom Docker Network with ENV ↗](/knowledge-base/define-custom-docker-network-with-env) or the [Create Root User with ENV ↗](/knowledge-base/create-root-user-with-env) for more details.
+See the [Define Custom Docker Network with ENV](/knowledge-base/define-custom-docker-network-with-env) or the [Create Root User with ENV](/knowledge-base/create-root-user-with-env) for more details.
 
 #### 3. Access Coolify
+
 After installation, the script will display your Coolify URL (e.g., `http://203.0.113.1:8000`). Visit this URL, and you'll be redirected to a registration page to create your first admin account.
 
 ::: danger ⚠️ CAUTION:
@@ -164,6 +184,7 @@ If you installed Coolify on a Raspberry Pi within your home network, use your pr
 :::
 
 #### What the Installer Does:
+
 - Installs essential tools (curl, wget, git, jq, openssl)
 - Installs Docker Engine (version 24+)
 - Configures Docker settings (logging, daemon)
@@ -179,19 +200,21 @@ Docker installed via snap is not supported!
 
 ---
 
-
 ### Manual Installation
+
 For those who prefer more control, you can install Coolify manually. This method requires a few extra steps.
 
 ::: info Note
 This manual installation method is required for:
+
 - Non-LTS Ubuntu versions (e.g., 24.10)
 - Systems where the automatic script encounters issues
-:::
+  :::
 
 #### Prerequisites
-- **SSH**: Ensure SSH is enabled and set up correctly (see [SSH Configuration Guide ↗](/knowledge-base/server/openssh)).
-- **curl**: Confirm that [curl ↗](https://curl.se/) is installed.
+
+- **SSH**: Ensure SSH is enabled and set up correctly (see [SSH Configuration Guide](/knowledge-base/server/openssh)).
+- **curl**: Confirm that [curl](https://curl.se/) is installed.
 - **Docker Engine**: Install Docker by following the official [Docker Engine Installation guide](https://docs.docker.com/engine/install/#server) (version 24+).
 
 ::: warning ⚠️ Caution:
@@ -203,7 +226,9 @@ Docker installed via snap is not supported!
 Follow these steps for a manual setup:
 
 #### 1. Create Directories
+
 Create the base directories for Coolify under `/data/coolify`:
+
 ```sh
 mkdir -p /data/coolify/{source,ssh,applications,databases,backups,services,proxy,webhooks-during-maintenance}
 mkdir -p /data/coolify/ssh/{keys,mux}
@@ -211,11 +236,15 @@ mkdir -p /data/coolify/proxy/dynamic
 ```
 
 #### 2. Generate & Add SSH Key
+
 Generate an SSH key for Coolify to manage your server:
+
 ```sh
 ssh-keygen -f /data/coolify/ssh/keys/id.root@host.docker.internal -t ed25519 -N '' -C root@coolify
 ```
+
 Then, add the public key to your `~/.ssh/authorized_keys`:
+
 ```sh
 cat /data/coolify/ssh/keys/id.root@host.docker.internal.pub >> ~/.ssh/authorized_keys
 chmod 600 ~/.ssh/authorized_keys
@@ -226,7 +255,9 @@ If you already have an SSH key, you can skip generating a new one, but remember 
 :::
 
 #### 3. Setup Configuration Files
+
 Download the necessary files from Coolify’s CDN to `/data/coolify/source`:
+
 ```sh
 curl -fsSL https://cdn.coollabs.io/coolify/docker-compose.yml -o /data/coolify/source/docker-compose.yml
 curl -fsSL https://cdn.coollabs.io/coolify/docker-compose.prod.yml -o /data/coolify/source/docker-compose.prod.yml
@@ -235,14 +266,18 @@ curl -fsSL https://cdn.coollabs.io/coolify/upgrade.sh -o /data/coolify/source/up
 ```
 
 #### 4. Set Permissions
+
 Set the correct permissions for the Coolify files and directories:
+
 ```sh
 chown -R 9999:root /data/coolify
 chmod -R 700 /data/coolify
 ```
 
 #### 5. Generate Values
+
 Update the `.env` file with secure random values:
+
 ```sh
 sed -i "s|APP_ID=.*|APP_ID=$(openssl rand -hex 16)|g" /data/coolify/source/.env
 sed -i "s|APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|g" /data/coolify/source/.env
@@ -258,13 +293,17 @@ Run these commands only the first time you install Coolify. Changing these value
 :::
 
 #### 6. Create Docker Network
+
 Ensure the Docker network is created:
+
 ```sh
 docker network create --attachable coolify
 ```
 
 #### 7. Start Coolify
+
 Launch Coolify using Docker Compose:
+
 ```sh
 docker compose --env-file /data/coolify/source/.env -f /data/coolify/source/docker-compose.yml -f /data/coolify/source/docker-compose.prod.yml up -d --pull always --remove-orphans --force-recreate
 ```
@@ -274,6 +313,7 @@ You might have to do `docker login` at this point if you have any issues above.
 :::
 
 #### 8. Access Coolify
+
 You can now access Coolify by visiting `http://203.0.113.1:8000` (replace the `203.0.113.1` with the IP address of your server).
 
-If you get stuck at any step, feel free to join our [Discord community ↗](https://coolify.io/discord) and create a post in the support forum channel.
+If you get stuck at any step, feel free to join our [Discord community](https://coolify.io/discord) and create a post in the support forum channel.

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -12,15 +12,15 @@ editLink: true
 
 ## What is Coolify?
 
-Coolify is a software that makes self-hosting simple and powerful. It lets you run your applications, databases, and services on your own server, whether that’s an old laptop, a Raspberry Pi, or a rented server from a provider like [Hetzner ↗](https://coolify.io/hetzner). 
+Coolify is a software that makes self-hosting simple and powerful. It lets you run your applications, databases, and services on your own server, whether that’s an old laptop, a Raspberry Pi, or a rented server from a provider like [Hetzner](https://coolify.io/hetzner).
 
-With Coolify, you get full control over your projects, your data, and your costs. It’s completely free to use, open-source, and has no features locked behind a paywall. 
+With Coolify, you get full control over your projects, your data, and your costs. It’s completely free to use, open-source, and has no features locked behind a paywall.
 
-Think of Coolify as your personal alternative to cloud platforms like [Vercel ↗](https://vercel.com?utm_source=coolify.io), [Railway ↗](https://railway.com/?utm_source=coolify.io), or [Heroku ↗](https://www.heroku.com/?utm_source=coolify.io), but without the huge bills or privacy trade-offs.
+Think of Coolify as your personal alternative to cloud platforms like [Vercel](https://vercel.com?utm_source=coolify.io), [Railway](https://railway.com/?utm_source=coolify.io), or [Heroku](https://www.heroku.com/?utm_source=coolify.io), but without the huge bills or privacy trade-offs.
 
 ### What Coolify Is Not
 
-Coolify isn’t a cloud service that hosts everything for you, you need your own server. That could be your old laptop, a Raspberry Pi, or a rented server from a hosting provider like [Hetzner ↗](https://coolify.io/hetzner), and you’ll need SSH access to use it. 
+Coolify isn’t a cloud service that hosts everything for you, you need your own server. That could be your old laptop, a Raspberry Pi, or a rented server from a hosting provider like [Hetzner](https://coolify.io/hetzner), and you’ll need SSH access to use it.
 
 It’s not a zero-effort solution either, if you choose to self-host, you’ll need to set up your server and install Coolify. But once it’s running, managing your projects becomes very easy.
 
@@ -28,66 +28,69 @@ It’s not a zero-effort solution either, if you choose to self-host, you’ll n
 
 Coolify is loaded with tools to make self-hosting smooth and powerful. Here’s a detailed look at what it offers:
 
-| Features                  | Explanation                                                                                              |
-|:--------------------------|:---------------------------------------------------------------------------------------------------------|
-| **Any Language**          | Deploy static sites, APIs, backends, databases, and more with support for all major frameworks.          |
-| **Any Server**            | Deploy to any server - VPS, Raspberry Pi, EC2, your laptop via SSH.                                      |
-| **Any Use-Case**          | Supports single servers, multi-server setups, and Docker Swarm clusters (Kubernetes support coming soon).|
-| **Any Service**           | Deploy any Docker-compatible service, plus a wide range of one-click options.                            |
-| **Push to Deploy**        | Git integration with GitHub, GitLab, Bitbucket, Gitea, and other platforms.                              |
-| **Free SSL Certificates**  | Automatically sets up and renews Let's Encrypt SSL certificates for custom domains.                       |
-| **No Vendor Lock-In**     | Your data and settings stay on your servers for full control and easy portability.                       |
-| **Automatic Backups**     | Back up data to S3-compatible storage and restore it with one click if needed.                           |
-| **Webhooks**              | Integrate with CI/CD tools like GitHub Actions, GitLab CI, or Bitbucket Pipelines.                       |
-| **Powerful API**          | Automate deployments, manage resources, and integrate with your existing tools easily.                   | 
-| **Real-Time Terminal**    | Run server commands directly from your browser in real-time.                                             |
-| **Collaborative**         | Share projects with your team, control roles, and manage permissions.                                    |
-| **PR Deployments**        | Deploy commits and pull requests separately for quick reviews and faster teamwork.                       |
-| **Server Automations**    | Handles server setup tasks automatically after connection, saving you time.                              |
-| **Monitoring**            | Monitor deployments, servers, disk usage, and receive alerts for issues.                                 |
+| Features                  | Explanation                                                                                               |
+| :------------------------ | :-------------------------------------------------------------------------------------------------------- |
+| **Any Language**          | Deploy static sites, APIs, backends, databases, and more with support for all major frameworks.           |
+| **Any Server**            | Deploy to any server - VPS, Raspberry Pi, EC2, your laptop via SSH.                                       |
+| **Any Use-Case**          | Supports single servers, multi-server setups, and Docker Swarm clusters (Kubernetes support coming soon). |
+| **Any Service**           | Deploy any Docker-compatible service, plus a wide range of one-click options.                             |
+| **Push to Deploy**        | Git integration with GitHub, GitLab, Bitbucket, Gitea, and other platforms.                               |
+| **Free SSL Certificates** | Automatically sets up and renews Let's Encrypt SSL certificates for custom domains.                       |
+| **No Vendor Lock-In**     | Your data and settings stay on your servers for full control and easy portability.                        |
+| **Automatic Backups**     | Back up data to S3-compatible storage and restore it with one click if needed.                            |
+| **Webhooks**              | Integrate with CI/CD tools like GitHub Actions, GitLab CI, or Bitbucket Pipelines.                        |
+| **Powerful API**          | Automate deployments, manage resources, and integrate with your existing tools easily.                    |
+| **Real-Time Terminal**    | Run server commands directly from your browser in real-time.                                              |
+| **Collaborative**         | Share projects with your team, control roles, and manage permissions.                                     |
+| **PR Deployments**        | Deploy commits and pull requests separately for quick reviews and faster teamwork.                        |
+| **Server Automations**    | Handles server setup tasks automatically after connection, saving you time.                               |
+| **Monitoring**            | Monitor deployments, servers, disk usage, and receive alerts for issues.                                  |
 
 ## Benefits of Using Coolify
+
 Coolify delivers unbeatable advantages for developers who want to self-host. Here’s why it stands out:
 
-| Benefits                     | Explanation                                                                                                    |
-|:--------------------------- |:-------------------------------------------------------------------------------------------------------------- |
-| **Cost Savings**            | Avoid skyrocketing cloud costs. Use your own server for a steady, predictable price.                           |
-| **No Hidden Costs**         | Transparent pricing with no unexpected charges.                                                                |
-| **Highly Cost-Efficient**    | Save thousands monthly compared to traditional cloud platforms. Real examples can be found [here ↗](https://twitter.com/heyandras/status/1742078215986860460), [here ↗](https://twitter.com/heyandras/status/1752209429276086688), and [here ↗](https://twitter.com/heyandras/status/1724510876256944244)           |
-| **Complete Data Privacy**   | Your data stays on your server, ensuring total control and security.                                           |
-| **No Feature Restrictions** | All features are included in the open-source version—nothing locked behind a paywall.                          |
-| **Unlimited Usage**         | Deploy unlimited websites and applications across any number of servers.                                       |
-| **Quick Setup**             | Start hosting in minutes with minimal maintenance required.                                                    |
-| **User-Friendly Interface** | Manage your infrastructure through a clean, simple dashboard designed for developers.                          |
-| **100% Open Source**        | Review the code, contribute to development, and help shape the platform’s future.                              |
-| **Active Community**        | Join over 16,000 people on Discord and 204,000+ servers running Coolify worldwide.                             |
-
+| Benefits                    | Explanation                                                                                                                                                                                                                                                                                         |
+| :-------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cost Savings**            | Avoid skyrocketing cloud costs. Use your own server for a steady, predictable price.                                                                                                                                                                                                                |
+| **No Hidden Costs**         | Transparent pricing with no unexpected charges.                                                                                                                                                                                                                                                     |
+| **Highly Cost-Efficient**   | Save thousands monthly compared to traditional cloud platforms. Real examples can be found [here](https://twitter.com/heyandras/status/1742078215986860460), [here](https://twitter.com/heyandras/status/1752209429276086688), and [here](https://twitter.com/heyandras/status/1724510876256944244) |
+| **Complete Data Privacy**   | Your data stays on your server, ensuring total control and security.                                                                                                                                                                                                                                |
+| **No Feature Restrictions** | All features are included in the open-source version—nothing locked behind a paywall.                                                                                                                                                                                                               |
+| **Unlimited Usage**         | Deploy unlimited websites and applications across any number of servers.                                                                                                                                                                                                                            |
+| **Quick Setup**             | Start hosting in minutes with minimal maintenance required.                                                                                                                                                                                                                                         |
+| **User-Friendly Interface** | Manage your infrastructure through a clean, simple dashboard designed for developers.                                                                                                                                                                                                               |
+| **100% Open Source**        | Review the code, contribute to development, and help shape the platform’s future.                                                                                                                                                                                                                   |
+| **Active Community**        | Join over 16,000 people on Discord and 204,000+ servers running Coolify worldwide.                                                                                                                                                                                                                  |
 
 ## Getting Started with Coolify
-Before you jump into using Coolify, it’s worth understanding a few key concepts to make your journey smoother. 
 
-Learn about servers, SSH access, and how Coolify manages your projects by checking out our [concepts guide ↗](/get-started/concepts).
+Before you jump into using Coolify, it’s worth understanding a few key concepts to make your journey smoother.
+
+Learn about servers, SSH access, and how Coolify manages your projects by checking out our [concepts guide](/get-started/concepts).
 
 You have two ways to use Coolify:
+
 - [Self-Host Coolify](#self-host-coolify)
 - [Use Coolify Cloud](#use-coolify-cloud)
 
 ---
 
 ### Self-Host Coolify
-  - Install Coolify on your own server. This requires setting up the server, installing Coolify, and handling updates yourself. 
-  - You’ll also need to allocate some server resources to run Coolify. 
-  - It’s completely free (except your server bills) and gives you full control over your infrastructure.
 
+- Install Coolify on your own server. This requires setting up the server, installing Coolify, and handling updates yourself.
+- You’ll also need to allocate some server resources to run Coolify.
+- It’s completely free (except your server bills) and gives you full control over your infrastructure.
 
 ### Use Coolify Cloud
-  - Let the Coolify team manage Coolify for you. 
-  - With Coolify Cloud, you don’t need to install or update Coolify yourself, and no server resources are required for Coolify itself, it runs on the Coolify team’s managed servers. 
-  - Simply create an account from [here ↗](https://app.coolify.io/register), connect your servers via SSH keys, and start deploying. 
-  This is a paid service (starting at $5/mo), as it costs the team to host and maintain the infrastructure. 
-  - Updates on Coolify Cloud are thoroughly tested by the core team, so they might be slightly delayed for added stability.
 
+- Let the Coolify team manage Coolify for you.
+- With Coolify Cloud, you don’t need to install or update Coolify yourself, and no server resources are required for Coolify itself, it runs on the Coolify team’s managed servers.
+- Simply create an account from [here](https://app.coolify.io/register), connect your servers via SSH keys, and start deploying.
+  This is a paid service (starting at $5/mo), as it costs the team to host and maintain the infrastructure.
+- Updates on Coolify Cloud are thoroughly tested by the core team, so they might be slightly delayed for added stability.
 
 ## Join Our Community
-Got questions or need support? Our [discord community](https://coollabs.io/discord) is here to help. 
+
+Got questions or need support? Our [discord community](https://coollabs.io/discord) is here to help.
 Connect with other Coolify users on our community server to get assistance and share your experiences.

--- a/docs/get-started/support.md
+++ b/docs/get-started/support.md
@@ -7,16 +7,19 @@ description: Get Coolify support through Discord community with 13K+ members, di
 
 <br />
 
-## Community Support  
-Join our [Discord community ↗](https://coollabs.io/discord) with over **13K members**, where you can create a post in the **support forum channel** for assistance. 
+## Community Support
 
-While the community does provide some help, the [Core team ↗](/get-started/team) is actively involved in the forum to ensure questions are addressed.  
+Join our [Discord community](https://coollabs.io/discord) with over **13K members**, where you can create a post in the **support forum channel** for assistance.
+
+While the community does provide some help, the [Core team](/get-started/team) is actively involved in the forum to ensure questions are addressed.
 
 ## Direct Support from Core Developers
-If you are a **Coolify Cloud user**, you can reach out via email at **hi@coollabs.io** for direct support from [Andras (Coolify’s founder)](https://x.com/heyandras). Since he personally handles emails, response times may be delayed. 
 
-We highly recommend posting in the **Discord support forum** first, as core team members can escalate issues to the developers ([Andras](https://x.com/heyandras) & [Peak](https://x.com/peaklabs_dev)) if necessary.  
+If you are a **Coolify Cloud user**, you can reach out via email at **hi@coollabs.io** for direct support from [Andras (Coolify’s founder)](https://x.com/heyandras). Since he personally handles emails, response times may be delayed.
 
-## Important Notes  
-- We are a **small team** (fewer than **6 people**) supporting **140K+ users**, making it challenging to offer direct assistance to everyone. However, we do our best to help as much as possible.  
+We highly recommend posting in the **Discord support forum** first, as core team members can escalate issues to the developers ([Andras](https://x.com/heyandras) & [Peak](https://x.com/peaklabs_dev)) if necessary.
+
+## Important Notes
+
+- We are a **small team** (fewer than **6 people**) supporting **140K+ users**, making it challenging to offer direct assistance to everyone. However, we do our best to help as much as possible.
 - We are planning a **paid support option** for **self-hosted users**. If you need dedicated support for your **self-hosted instance**, email **hi@coollabs.io** to discuss options.

--- a/docs/get-started/uninstallation.md
+++ b/docs/get-started/uninstallation.md
@@ -7,61 +7,71 @@ description: Completely remove Coolify from your self-hosted server by stopping 
 
 <br />
 
-If you're using [Coolify Cloud ↗](https://coolify.io/pricing/), you don't need to uninstall Coolify since the Coolify Team manages everything on their servers. 
+If you're using [Coolify Cloud](https://coolify.io/pricing/), you don't need to uninstall Coolify since the Coolify Team manages everything on their servers.
 
-To stop using Coolify Cloud, simply visit the [Billing page ↗](https://app.coolify.io/subscription/) and cancel your subscription.
+To stop using Coolify Cloud, simply visit the [Billing page](https://app.coolify.io/subscription/) and cancel your subscription.
 
 For those who **self-host** Coolify and wish to remove it from your server, follow the steps below to uninstall it safely:
+
 - [Stop and Remove Containers](#_1-stop-and-remove-containers)
 - [Remove Docker Volumes](#_2-remove-docker-volumes)
 - [Remove Docker Network](#_3-remove-docker-network)
 - [Delete Coolify Data Directory](#_4-delete-coolify-data-directory)
 - [Remove Docker Images](#_5-remove-docker-images)
 
-
 ## 1. Stop and Remove Containers
+
 Stop all Coolify-related Docker containers and remove them to free up system resources.
 
 Run the following commands in your terminal:
+
 ```sh
 sudo docker stop -t 0 coolify coolify-realtime coolify-db coolify-redis coolify-proxy coolify-sentinel
 sudo docker rm coolify coolify-realtime coolify-db coolify-redis coolify-proxy coolify-sentinel
 ```
+
 The `-t 0` flag ensures that the containers stop immediately without waiting for a timeout.
 
-
 ## 2. Remove Docker Volumes
+
 To remove the persistent data stored in Docker volumes for Coolify, run:
+
 ```sh
 sudo docker volume rm coolify-db coolify-redis
 ```
+
 ::: danger CAUTION!!
-  Removing volumes will delete all data stored in them permanently. Ensure you have backups if needed.
+Removing volumes will delete all data stored in them permanently. Ensure you have backups if needed.
 :::
 
-
 ## 3. Remove Docker Network
+
 Coolify uses a custom Docker network named coolify. Remove it with the following command:
+
 ```sh
 sudo docker network rm coolify
 ```
+
 ::: info Info
-  If you encounter an error indicating the network is in use, ensure that no containers are using the network before retrying.
+If you encounter an error indicating the network is in use, ensure that no containers are using the network before retrying.
 :::
 
-
 ## 4. Delete Coolify Data Directory
+
 Remove the directory where Coolify stores its data on your server:
+
 ```sh
   sudo rm -rf /data/coolify
 ```
+
 ::: danger CAUTION!
-  This will permanently delete all Coolify-related data. Double-check the directory path before executing this command.
+This will permanently delete all Coolify-related data. Double-check the directory path before executing this command.
 :::
 
-
 ## 5. Remove Docker Images
+
 To free up disk space, remove all Docker images used by Coolify by running the following commands:
+
 ```sh
 sudo docker rmi ghcr.io/coollabsio/coolify:latest
 sudo docker rmi ghcr.io/coollabsio/coolify-helper:latest
@@ -71,11 +81,13 @@ sudo docker rmi redis:alpine
 ```
 
 If you were using the default proxy, also remove its image:
+
 ```sh
 sudo docker rmi traefik:v3.1
 ```
 
 If you switched to the Caddy proxy, remove its image instead:
+
 ```sh
 sudo docker rmi lucaslorentz/caddy-docker-proxy:2.8-alpine
 ```
@@ -83,4 +95,5 @@ sudo docker rmi lucaslorentz/caddy-docker-proxy:2.8-alpine
 ---
 
 ### Coolify Successfully Uninstalled
+
 After completing these steps, Coolify and all its related resources will be completely removed from your server.

--- a/docs/get-started/upgrade.md
+++ b/docs/get-started/upgrade.md
@@ -7,7 +7,7 @@ description: Upgrade self-hosted Coolify automatically, semi-automatically with 
 
 <br />
 
-If you're using [Coolify Cloud ↗](https://coolify.io/pricing/), the Coolify team handles all updates so you don’t need to worry about them. 
+If you're using [Coolify Cloud](https://coolify.io/pricing/), the Coolify team handles all updates so you don’t need to worry about them.
 
 For those who **self-host** Coolify, there are three ways to upgrade your instance:
 
@@ -15,18 +15,21 @@ For those who **self-host** Coolify, there are three ways to upgrade your instan
 - [Semi-Automatic Upgrade:](#_2-semi-automatic-upgrade) For users who want control over when to apply updates.
 - [Manual Upgrade:](#_3-manual-upgrade) For advanced users who prefer to manage the upgrade process themselves.
 
-:::danger **Backup First!**  
-  > **Always back up your Coolify data before starting an upgrade.**
-:::
+:::danger **Backup First!**
 
+> **Always back up your Coolify data before starting an upgrade.**
+> :::
 
 ## 1. Automatic Upgrade
+
 Coolify can update itself automatically. This option keeps your instance always up-to-date without any extra effort.
 
 ### How it works?
-Coolify periodically checks the [CDN ↗](https://cdn.coollabs.io/coolify/versions.json) for updates. When a new version is available, it automatically fetches the latest release from the [official repository ↗](https://github.com/orgs/coollabsio/packages?repo_name=coolify) and starts the upgrade process on its own.
 
-### Customize Automatic Updates  
+Coolify periodically checks the [CDN](https://cdn.coollabs.io/coolify/versions.json) for updates. When a new version is available, it automatically fetches the latest release from the [official repository](https://github.com/orgs/coollabsio/packages?repo_name=coolify) and starts the upgrade process on its own.
+
+### Customize Automatic Updates
+
 If you’d rather manage updates yourself, you can disable auto-updates in your Coolify dashboard’s Settings.
 
 <ZoomableImage src="/docs/images/get-started/upgrade/disable-auto-update.webp" alt="Disable Auto Update" />
@@ -35,18 +38,20 @@ If you’d rather manage updates yourself, you can disable auto-updates in your 
 Turning off automatic updates lets you test a new version on a staging setup before updating your live environment.
 :::
 
-
 ## 2. Semi-Automatic Upgrade
+
 This option gives you a bit more control. Coolify notifies you when an update is available, and you decide when to apply it.
 
 ### How it works?
-Coolify periodically checks the [CDN ↗](https://cdn.coollabs.io/coolify/versions.json) for updates. When a new version is available, you will see an "**Upgrade**" button in the sidebar of your Coolify dashboard.
+
+Coolify periodically checks the [CDN](https://cdn.coollabs.io/coolify/versions.json) for updates. When a new version is available, you will see an "**Upgrade**" button in the sidebar of your Coolify dashboard.
 
 <ZoomableImage src="/docs/images/get-started/upgrade/upgrade-button-ui.webp" alt="Upgrade Button Ui" />
 
 Click the upgrade button to start the update process.
 
 ### Set Update Frequency
+
 You can also choose how often Coolify checks for updates by adjusting the settings (daily, weekly, etc.).
 
 <ZoomableImage src="/docs/images/get-started/upgrade/change-frequency.webp" alt="Change Frequency" />
@@ -55,11 +60,12 @@ You can also choose how often Coolify checks for updates by adjusting the settin
 This method is perfect if you want to review update details or test the upgrade before applying it.
 :::
 
-
 ## 3. Manual Upgrade
+
 For those who prefer full control, you can upgrade Coolify manually.
 
 ### How to do this?
+
 Open your server's terminal and run the command below:
 
 ```sh
@@ -67,18 +73,19 @@ curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
 ```
 
 To upgrade to a specific version, run the following command in your terminal:
+
 ```sh
 curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.0.0-beta.400
 ```
-Replace `4.0.0-beta.400` with the version number you want to upgrade to. 
 
+Replace `4.0.0-beta.400` with the version number you want to upgrade to.
 
 ### How it works?
-This command runs the official [Coolify installation script ↗](https://github.com/coollabsio/coolify/blob/main/scripts/install.sh). The script checks the [CDN ↗](https://cdn.coollabs.io/coolify/versions.json) for the latest version and updates your Coolify Instance.
 
+This command runs the official [Coolify installation script](https://github.com/coollabsio/coolify/blob/main/scripts/install.sh). The script checks the [CDN](https://cdn.coollabs.io/coolify/versions.json) for the latest version and updates your Coolify Instance.
 
 ::: success Tip
-In the Automatic and Semi-Automatic methods, Coolify runs the installation script automatically in the background. 
+In the Automatic and Semi-Automatic methods, Coolify runs the installation script automatically in the background.
 
 In the Manual upgrade method, you run the script yourself.
 :::

--- a/docs/get-started/usage.md
+++ b/docs/get-started/usage.md
@@ -7,48 +7,48 @@ description: Compare Coolify Cloud managed service starting at $5/month versus f
 
 <br />
 
-So, you’ve decided to use Coolify, awesome choice! 
+So, you’ve decided to use Coolify, awesome choice!
 
 Now, you might be wondering whether to go with **Coolify Cloud** or set it up yourself through **self-hosting**. Let’s break it down so you can pick the best option for you.
 
-
 ## Coolify Cloud
-Coolify Cloud is the easy way to get started. It’s a paid service (starting at just **$5 a month**) where you bring your own servers and connect them to a Coolify instance that’s fully managed by our team. 
 
-::: warning **Note** 
-  **We host and update the Coolify instance for you, so you don't have to allocate any of your server resources to Coolify, but you’re still responsible for your own servers and any other services running on them**
+Coolify Cloud is the easy way to get started. It’s a paid service (starting at just **$5 a month**) where you bring your own servers and connect them to a Coolify instance that’s fully managed by our team.
+
+::: warning **Note**
+**We host and update the Coolify instance for you, so you don't have to allocate any of your server resources to Coolify, but you’re still responsible for your own servers and any other services running on them**
 :::
 
+## Coolify Self-Hosted
 
-## Coolify Self-Hosted 
-If you’re more of a hands-on person, self-hosting Coolify might be your thing. 
+If you’re more of a hands-on person, self-hosting Coolify might be your thing.
 
-It’s completely free (except for your server costs, of course), and you get to control everything. 
+It’s completely free (except for your server costs, of course), and you get to control everything.
 
-You’ll install Coolify on your own server, keep it updated, and manage all the related services yourself. 
-
+You’ll install Coolify on your own server, keep it updated, and manage all the related services yourself.
 
 ## How Do They Compare?
-*All of the features below refer only to the Coolify instance, not your entire server or other services.*
 
-| Feature                  | Coolify Cloud                                                                 | Self-Hosted Coolify                                  |
-|------------------------- |------------------------------------------------------------------------------ |----------------------------------------------------- |
-| **Maintenance**          | We take care of hosting and updating the Coolify instance for you             | You’re in charge of keeping the instance running smoothly |
-| **Support**              | Help from Coolify experts and our core team                                   | Chat with the community on Discord                   |
-| **Email Notifications**   | Pre-configured and ready to use for free                                       | You’ll need to set this up yourself                   |
-| **Backups**              | We handle automatic backups for your Coolify instance                         | Set up your own backup system for the Coolify instance        |
-| **High Availability**    | We’ve got you covered with reliable uptime for the Coolify instance           | Depends on how you set things up                      |
-| **Stability**            | We test updates thoroughly before rolling them out                            | Test updates yourself before upgrading                |
-| **Cost**                 | Starts at **$5/month**                                                        | Free forever (just pay for your server)               |
+_All of the features below refer only to the Coolify instance, not your entire server or other services._
 
-And just so you know, we don’t play the “**feature lock**” game. Whether you choose Coolify Cloud or self-host, you get all the same powerful features. 
+| Feature                 | Coolify Cloud                                                       | Self-Hosted Coolify                                       |
+| ----------------------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
+| **Maintenance**         | We take care of hosting and updating the Coolify instance for you   | You’re in charge of keeping the instance running smoothly |
+| **Support**             | Help from Coolify experts and our core team                         | Chat with the community on Discord                        |
+| **Email Notifications** | Pre-configured and ready to use for free                            | You’ll need to set this up yourself                       |
+| **Backups**             | We handle automatic backups for your Coolify instance               | Set up your own backup system for the Coolify instance    |
+| **High Availability**   | We’ve got you covered with reliable uptime for the Coolify instance | Depends on how you set things up                          |
+| **Stability**           | We test updates thoroughly before rolling them out                  | Test updates yourself before upgrading                    |
+| **Cost**                | Starts at **$5/month**                                              | Free forever (just pay for your server)                   |
+
+And just so you know, we don’t play the “**feature lock**” game. Whether you choose Coolify Cloud or self-host, you get all the same powerful features.
 
 We’re all about giving you the full Coolify experience, no matter which path you take.
 
-
 ## Which One is Right for You?
-If you want a quick, easy setup and don’t mind paying a small fee for convenience, **Coolify Cloud** is perfect. 
+
+If you want a quick, easy setup and don’t mind paying a small fee for convenience, **Coolify Cloud** is perfect.
 
 But if you love getting hands-on, want to save every penny, and enjoy being in full control, **Self-Hosting** is the way to go.
 
-If you're still not sure which path to take, join our [Discord community ↗](https://coolify.io/discord) and ask any questions you might have! We're here to help you decide what's best for your needs.
+If you're still not sure which path to take, join our [Discord community](https://coolify.io/discord) and ask any questions you might have! We're here to help you decide what's best for your needs.

--- a/docs/integrations/webstudio.md
+++ b/docs/integrations/webstudio.md
@@ -4,119 +4,120 @@ description: Complete guide to deploying Webstudio projects with Coolify on Hetz
 ---
 
 # Deploy Webstudio Projects using Coolify
-Coolify makes deploying your Webstudio projects to Hetzner as simple as it is powerful. 
+
+Coolify makes deploying your Webstudio projects to Hetzner as simple as it is powerful.
 
 In this guide, you’ll learn how to set up your project, deploy it on a Hetzner server, and keep your infrastructure fully under your control, all with a few straightforward steps.
 
 ::: warning HEADS UP!
-  In this guide, we are using servers from Hetzner. 
-  
-  However, if you're using a different hosting provider, you can still follow this guide with their servers as well.
+In this guide, we are using servers from Hetzner.
 
-  If you prefer watching a video instead of reading, you can check out the [tutorial video ↗](https://youtu.be/OnHLO2Plt2E?si=yDM77oK7Xd5UsRSP)
+However, if you're using a different hosting provider, you can still follow this guide with their servers as well.
+
+If you prefer watching a video instead of reading, you can check out the [tutorial video](https://youtu.be/OnHLO2Plt2E?si=yDM77oK7Xd5UsRSP)
 :::
 
 ## What You’ll Need
+
 Before you start, make sure you have:
 
-- A [GitHub account ↗](https://github.com?utm_source=coolify.io) to host your code.
-- A [Hetzner account ↗](https://coolify.io/hetzner) to provision your server (or an account with any other hosting provider).
-- The [Webstudio CLI ↗](https://docs.webstudio.is/university/self-hosting/cli?utm_source=coolify.io) installed locally to manage your project exports.
-
+- A [GitHub account](https://github.com?utm_source=coolify.io) to host your code.
+- A [Hetzner account](https://coolify.io/hetzner) to provision your server (or an account with any other hosting provider).
+- The [Webstudio CLI](https://docs.webstudio.is/university/self-hosting/cli?utm_source=coolify.io) installed locally to manage your project exports.
 
 ## 1. Create Your GitHub Repository
-Start by [creating a new repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) on GitHub where you’ll store your Webstudio project code. 
+
+Start by [creating a new repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) on GitHub where you’ll store your Webstudio project code.
 
 Once the repository is created, [clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local machine to start developing locally.
 
-
 ## 2. Export Your Webstudio Project
-Using the Webstudio [CLI ↗](https://docs.webstudio.is/university/self-hosting/cli), export your project and select the "**Docker**" option. 
+
+Using the Webstudio [CLI](https://docs.webstudio.is/university/self-hosting/cli), export your project and select the "**Docker**" option.
 
 This prepares your project for deployment via Coolify without the need for additional dependency installations.
 
-
 ## 3. Push Your Code to GitHub
+
 With your project exported locally, [push your code](https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository) to the GitHub repository you created. This makes your project accessible for deployment.
 
-
 ## 4. Set Up Your Hetzner Server
+
 ::: warning HEADS UP!
-If you already have a server, you don't need to purchase a new one. 
+If you already have a server, you don't need to purchase a new one.
 
 **Webstudio recommends** that your server should have at least **1 CPU and 2GB of RAM** for smooth operation.
-  
-Skip to [Step 6 ↗](#_6-configure-your-project-on-coolify) if your server is already connected to Coolify.
+
+Skip to [Step 6](#_6-configure-your-project-on-coolify) if your server is already connected to Coolify.
 :::
 Follow these steps to prepare your Hetzner server:
 
-1. **Create a New Server:** Log into [Hetzner Cloud Dashboard ↗](https://console.hetzner.cloud/) and create a new server.
-  <ZoomableImage src="/docs/images/resources/integrations/1.webp" alt="Coolify dashboard screenshot" />
+1. **Create a New Server:** Log into [Hetzner Cloud Dashboard](https://console.hetzner.cloud/) and create a new server.
+   <ZoomableImage src="/docs/images/resources/integrations/1.webp" alt="Coolify dashboard screenshot" />
 
 1. **Choose Your Region:** Select the region that best suits your needs.
-  <ZoomableImage src="/docs/images/resources/integrations/2.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/2.webp" alt="Coolify dashboard screenshot" />
 
 1. **Select Ubuntu:** Pick an Ubuntu image (make sure it’s a Docker-supported version, check the [Docker Ubuntu requirements](https://docs.docker.com/engine/install/ubuntu/#os-requirements)).
-  <ZoomableImage src="/docs/images/resources/integrations/3.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/3.webp" alt="Coolify dashboard screenshot" />
 
 1. **Configure Resources:** A shared CPU with at least 2 GB RAM is recommended.
-  <ZoomableImage src="/docs/images/resources/integrations/4.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/4.webp" alt="Coolify dashboard screenshot" />
 
 1. **Allocate an IPv4 Address:** Make sure your server has a dedicated IPv4 address.
-  <ZoomableImage src="/docs/images/resources/integrations/5.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/5.webp" alt="Coolify dashboard screenshot" />
 
 1. **Finalize Setup:** Click **Create and Buy Now** and wait until your server is provisioned.
 
-2. **Save the IP:** Copy your server’s IPv4 address, it will be needed shortly.
-
+1. **Save the IP:** Copy your server’s IPv4 address, it will be needed shortly.
 
 ## 5. Connect Coolify to Your Server
 
 ::: warning HEADS UP!
-If your server is already connected to Coolify, skip to the [next step ↗](#_6-configure-your-project-on-coolify).
+If your server is already connected to Coolify, skip to the [next step](#_6-configure-your-project-on-coolify).
 :::
 
 1. **Add Private Key:** Login to your Coolify account (or create one if you’re new) and Add a new private key
-  <ZoomableImage src="/docs/images/resources/integrations/6.webp" alt="Coolify dashboard screenshot" />
-  <br />
-  <ZoomableImage src="/docs/images/resources/integrations/7.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/6.webp" alt="Coolify dashboard screenshot" />
+   <br />
+   <ZoomableImage src="/docs/images/resources/integrations/7.webp" alt="Coolify dashboard screenshot" />
 
 2. **Add a Server:** Navigate to the **Servers** tab and add a new server by entering your Hetzner server’s IPv4 address.
-  <ZoomableImage src="/docs/images/resources/integrations/8.webp" alt="Coolify dashboard screenshot" />
-  <br />
-  <ZoomableImage src="/docs/images/resources/integrations/9.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/8.webp" alt="Coolify dashboard screenshot" />
+   <br />
+   <ZoomableImage src="/docs/images/resources/integrations/9.webp" alt="Coolify dashboard screenshot" />
 
 3. **Validate Server:** Click **Validate Server & Install Docker Engine**. Coolify will automatically install all necessary components on your server.
-  <ZoomableImage src="/docs/images/resources/integrations/10.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/10.webp" alt="Coolify dashboard screenshot" />
 
 4. **Check Status:** Once finished, you should see a green **Proxy Running** status indicating everything is set up.
-  <ZoomableImage src="/docs/images/resources/integrations/11.webp" alt="Coolify dashboard screenshot" />
-
+   <ZoomableImage src="/docs/images/resources/integrations/11.webp" alt="Coolify dashboard screenshot" />
 
 ## 6. Configure Your Project on Coolify
+
 1. **Create a New Project:** Head to the **Projects** section and create a new project.
 
 2. **Add a Resource:** Add a new resource, selecting your GitHub repository as the source.
 
 3. **Connect Your Repository:** Use the GitHub app integration to grant access to your repository.
-  <ZoomableImage src="/docs/images/resources/integrations/12.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/12.webp" alt="Coolify dashboard screenshot" />
 
 4. **Select Build Pack:** Change the Build Pack to **Dockerfile** and click on continue button.
-  <ZoomableImage src="/docs/images/resources/integrations/13.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/13.webp" alt="Coolify dashboard screenshot" />
 
-5. **Configure Domains & Deploy:** Enter your domain in the domains field and Click **Deploy** and wait as Coolify builds and deploys your project. 
-  <ZoomableImage src="/docs/images/resources/integrations/14.webp" alt="Coolify dashboard screenshot" />
+5. **Configure Domains & Deploy:** Enter your domain in the domains field and Click **Deploy** and wait as Coolify builds and deploys your project.
+   <ZoomableImage src="/docs/images/resources/integrations/14.webp" alt="Coolify dashboard screenshot" />
 
 6. **Successful Deployment:** When deployment is complete, you’ll see a “Deployment is Finished” message.
 
 7. **Access Your Site:** Use the **links** button at the top of the project dashboard to visit your live site.
-  <ZoomableImage src="/docs/images/resources/integrations/15.webp" alt="Coolify dashboard screenshot" />
+   <ZoomableImage src="/docs/images/resources/integrations/15.webp" alt="Coolify dashboard screenshot" />
 
 8. **Optional – Third-Party Domains:** If your project loads images from external sources, add those domains as a comma-separated list under the environment variable `DOMAINS`. (make sure to restart the application after adding the variable)
-  <ZoomableImage src="/docs/images/resources/integrations/16.webp" alt="Coolify dashboard screenshot" />
-
+   <ZoomableImage src="/docs/images/resources/integrations/16.webp" alt="Coolify dashboard screenshot" />
 
 ## 7. Update Your Webstudio Site
+
 To publish updates and keep your site up to date, follow these steps:
 
 1. **Publish Changes:** In the Webstudio builder, click **Publish** to generate the latest build data.

--- a/docs/knowledge-base/cloudflare/origin-cert.md
+++ b/docs/knowledge-base/cloudflare/origin-cert.md
@@ -4,34 +4,37 @@ description: "Secure Coolify deployments with 15-year Cloudflare Origin Certific
 ---
 
 # Cloudflare Origin Certificate
+
 <br />
 <ZoomableImage src="/docs/images/knowledge-base/cf-origin-cert/header.webp" alt="Coolify header" />
 
-The Cloudflare Origin Certificate ensures secure communication between your server and Cloudflare when using Cloudflare’s Proxy, CDN, and security features. 
+The Cloudflare Origin Certificate ensures secure communication between your server and Cloudflare when using Cloudflare’s Proxy, CDN, and security features.
 
 It encrypts the data exchanged between your server and Cloudflare, keeping it safe.
 
 ### Why Use Cloudflare Origin Certificate with Coolify?
+
 1. No need for HTTP or DNS challenges to create certificates.
 2. Keep port 80 closed — everything happens securely over TLS.
 3. Longer certificate validity (15 years) — once set up, you don’t need to worry about renewing every few months.
 
 ### When to Avoid Using Cloudflare Origin Certificate
+
 1. If you need a free certificate for subdomains with multiple levels (e.g., app.sub.domain.com).
 2. The certificate is only trusted by Cloudflare, meaning if Cloudflare is down, nobody can access your apps and websites (via your domain).
 
 ---
 
 ::: info Example Data
-  The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
-  
-  - **IPv4 Address of Origin Server:** 203.0.113.1
-  - **Domain Name:** shadowarcanist.com
-  - **Username:** shadowarcanist
-:::
+The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
 
+- **IPv4 Address of Origin Server:** 203.0.113.1
+- **Domain Name:** shadowarcanist.com
+- **Username:** shadowarcanist
+  :::
 
 ## 1. Create the Origin Certificate
+
 To create your Cloudflare Origin Certificate, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-origin-cert/1.webp" alt="Screenshot of Origin Cert" />
@@ -48,14 +51,15 @@ You’ll be asked to choose a private key type, hostnames, and certificate valid
 2. Add the hostnames you want the certificate to cover.
 
 ::: warning HEADS UP!
-  - **`shadowarcanist.com`** will cover only the main domain.
-  - **`*.shadowarcanist.com`** will cover all subdomains.
-  
-  On Cloudflare’s free plan, wildcard certificates cover just one level of subdomains
-  
-  For example, it works for **`coolify.shadowarcanist.com`** but not **`www.coolify.shadowarcanist.com`**. 
-  
-  To cover multiple levels, you'll need to purchase the [Advanced Certificate Manager ↗](https://www.cloudflare.com/application-services/products/advanced-certificate-manager/)
+
+- **`shadowarcanist.com`** will cover only the main domain.
+- **`*.shadowarcanist.com`** will cover all subdomains.
+
+On Cloudflare’s free plan, wildcard certificates cover just one level of subdomains
+
+For example, it works for **`coolify.shadowarcanist.com`** but not **`www.coolify.shadowarcanist.com`**.
+
+To cover multiple levels, you'll need to purchase the [Advanced Certificate Manager](https://www.cloudflare.com/application-services/products/advanced-certificate-manager/)
 :::
 
 3. Set the certificate validity to **15 years**.
@@ -70,67 +74,79 @@ Your certificate will now be generated.
 
 Next, you'll add these to your server running Coolify and configure Coolify to use this certificate.
 
-
 ## 2. Add Certificate to Your Server
+
 SSH into your server or use Coolify's terminal feature. For this guide, I’m using SSH:
+
 ```sh
 ssh shadowarcanist@203.0.113.1
 ```
 
 Once logged in, navigate to the Coolify proxy directory:
+
 ```sh
 $ cd /data/coolify/proxy
 ```
 
 Check if you have a **certs** folder:
+
 ```sh
 $ ls
 > acme.json  docker-compose.yml  dynamic
 ```
 
 If there’s no **certs** folder, create it:
+
 ```sh
 $ mkdir certs
 ```
 
 Verify it was created:
+
 ```sh
 $ ls
 > acme.json  certs docker-compose.yml  dynamic
 ```
 
 Now, navigate into the **certs** directory:
+
 ```sh
 $ cd certs
 ```
 
 Create two new files for the certificate and private key:
+
 ```sh
 $ touch shadowarcanist.cert shadowarcanist.key
 ```
 
 Verify the files were created:
+
 ```sh
 $ ls
 > shadowarcanist.cert shadowarcanist.key
 ```
 
 Open the **shadowarcanist.cert** file and paste the certificate from the Cloudflare dashboard:
+
 ```sh
-$ nano shadowarcanist.cert 
+$ nano shadowarcanist.cert
 ```
+
 Save and exit after pasting the certificate.
 
 Do the same for the **shadowarcanist.key** file and paste the private key:
+
 ```sh
-$ nano shadowarcanist.key 
+$ nano shadowarcanist.key
 ```
+
 Save and exit.
 
 Now the origin certificate is installed on your server.
 
-
 ## 3. Set Up DNS Records and TLS Encryption
+
 To make the origin certificate work, configure your DNS records, enable TLS, and set up HTTP to HTTPS redirects in Cloudflare:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-origin-cert/4.webp" alt="Screenshot of Origin Cert" />
@@ -158,12 +174,12 @@ Finally, enable HTTP to HTTPS redirects:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-origin-cert/7.webp" alt="Screenshot of Origin Cert" />
 
-1. In Cloudflare, go to **SSL/TLS** 
+1. In Cloudflare, go to **SSL/TLS**
 2. Select **Edge Certificates**.
 3. Enable **Always Use HTTPS**.
 
-
 ## 4. Configure Coolify to Use the Origin Certificate
+
 Now, in your Coolify dashboard:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-origin-cert/8.webp" alt="Screenshot of Origin Cert" />
@@ -179,6 +195,7 @@ You will now be prompted to enter the Dynamic Configuration.
 
 1. Choose a name for your configuration.
 2. Enter the following details in the configuration field:
+
 ```sh
 tls:
   certificates:
@@ -188,7 +205,7 @@ tls:
 ```
 
 Adding Multiple Certificates (click to view)
- 
+
 ```sh
 tls:
   certificates:
@@ -202,20 +219,18 @@ tls:
       certFile: /traefik/certs/name3.cert
       keyFile: /traefik/certs/name3.key
 ```
- 
 
 3. Save the configuration
 
 From now on, Coolify will use the origin certificate for requests matching the hostname.
 
 ::: danger HEADS UP!
-  **All the steps below are optional. Coolify should already be using the origin certificate. Follow these steps only if you know what you're doing and want to simplify the configuration**
+**All the steps below are optional. Coolify should already be using the origin certificate. Follow these steps only if you know what you're doing and want to simplify the configuration**
 :::
 
-
-
 ## 5. Optional: Configure Traefik
-This step is optional but recommended for cleaning up unnecessary settings while self-hosting. 
+
+This step is optional but recommended for cleaning up unnecessary settings while self-hosting.
 
 Since you’re using an Origin Certificate, you no longer need HTTP challenges or port 80 open.
 
@@ -274,7 +289,7 @@ services:
 ```
 
 ::: info Note
-  The comments in this configuration explain each line. You can remove the comments when copying it into your configuration.
+The comments in this configuration explain each line. You can remove the comments when copying it into your configuration.
 :::
 
 Next, you'll need to remove a few labels from your Dockerfile-based deployments. Below is an **example** of how I set this up for my website.
@@ -312,16 +327,17 @@ Now you’re done! Your server is set up to use the Cloudflare Origin Certificat
 ---
 
 ::: warning Note
-  Keep in mind that the above labels are provided as an example. These may or may not work for your specific use case, so use them as a reference.
+Keep in mind that the above labels are provided as an example. These may or may not work for your specific use case, so use them as a reference.
 :::
 
-
 ## Credits
-The header image is designed using icons from [Flaticon ↗](https://www.flaticon.com/). 
+
+The header image is designed using icons from [Flaticon](https://www.flaticon.com/).
 Links to each icon can be found below:
-- [Medal icon ↗](https://www.flaticon.com/free-icon/medal_14468558) by [Vlad Szirka ↗](https://www.flaticon.com/authors/vlad-szirka)
-- [Award icon ↗](https://www.flaticon.com/free-icon/award_15218157) by [explanaicon ↗](https://www.flaticon.com/authors/explanaicon)
-- [Worldwide icon ↗](https://www.flaticon.com/free-icon/worldwide_870169) by [Freepik ↗](https://www.flaticon.com/authors/freepik)
-- [Lock icon ↗](https://www.flaticon.com/free-icon/lock_2089784) by [Those Icons ↗](https://www.flaticon.com/authors/those-icons)
-- [Browser icon ↗](https://www.flaticon.com/free-icon/browser_331190) by [Alfredo Hernandez ↗](https://www.flaticon.com/authors/alfredo-hernandez)
-- [Database icon ↗](https://www.flaticon.com/free-icon/database_8028666) by [Tanah Basah ↗](https://www.flaticon.com/authors/tanah-basah)
+
+- [Medal icon](https://www.flaticon.com/free-icon/medal_14468558) by [Vlad Szirka](https://www.flaticon.com/authors/vlad-szirka)
+- [Award icon](https://www.flaticon.com/free-icon/award_15218157) by [explanaicon](https://www.flaticon.com/authors/explanaicon)
+- [Worldwide icon](https://www.flaticon.com/free-icon/worldwide_870169) by [Freepik](https://www.flaticon.com/authors/freepik)
+- [Lock icon](https://www.flaticon.com/free-icon/lock_2089784) by [Those Icons](https://www.flaticon.com/authors/those-icons)
+- [Browser icon](https://www.flaticon.com/free-icon/browser_331190) by [Alfredo Hernandez](https://www.flaticon.com/authors/alfredo-hernandez)
+- [Database icon](https://www.flaticon.com/free-icon/database_8028666) by [Tanah Basah](https://www.flaticon.com/authors/tanah-basah)

--- a/docs/knowledge-base/cloudflare/tunnels/all-resource.md
+++ b/docs/knowledge-base/cloudflare/tunnels/all-resource.md
@@ -4,10 +4,11 @@ description: "Expose all Coolify resources securely through Cloudflare Tunnels w
 ---
 
 # Access All Resource via Cloudflare Tunnels
-Accessing All Resource deployed on Coolify using a Cloudflare Tunnel allows you to securely reach your app without exposing your server’s IP address or without having a Public IP address for the server. 
 
+Accessing All Resource deployed on Coolify using a Cloudflare Tunnel allows you to securely reach your app without exposing your server’s IP address or without having a Public IP address for the server.
 
 ## Who this is for?
+
 This setup is ideal for people who:
 
 - Don't have a public IP for their server (could be a laptop, rasberry pi etc..).
@@ -15,20 +16,20 @@ This setup is ideal for people who:
 - Want to keep their server’s IP address private and avoid exposing it to the public internet.
 - Have an resource already deployed on Coolify and need an external method to access it securely.
 
-
 ## Setup Requirements
+
 To follow this guide, you'll need:
 
-- A free [Cloudflare ↗](https://cloudflare.com) account.
+- A free [Cloudflare](https://cloudflare.com) account.
 - You need a domain that has it's **DNS managed by Cloudflare**.
 
-
 ## Before We Start
-- We assume you have Coolify running on your server.
-- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide ↗](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
 
+- We assume you have Coolify running on your server.
+- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
 
 ## How It Works?
+
 A simple high-level overview diagram to give you a visual idea of how this works:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/high-level-diagram.webp" alt="High Level Diagram configuration" />
@@ -36,6 +37,7 @@ A simple high-level overview diagram to give you a visual idea of how this works
 ---
 
 ### Quick Links to Important Sections:
+
 - [Create a Cloudflare Tunnel](#_1-create-a-cloudflare-tunnel)
 - [Setup Encryption mode on Cloudflare](#_2-setup-encryption-mode-on-cloudflare)
 - [Setup Cloudflare Tunnel on Coolify](#_3-setup-cloudflare-tunnel-on-coolify)
@@ -47,16 +49,16 @@ A simple high-level overview diagram to give you a visual idea of how this works
 ---
 
 ::: warning Example Data
-  The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
-  
-  - **Domain Name:** shadowarcanist.com
-:::
+The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
+
+- **Domain Name:** shadowarcanist.com
+  :::
 
 ---
 
-
 ## 1. Create a Cloudflare Tunnel
-To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust ↗](https://one.dash.cloudflare.com/) page.
+
+To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust](https://one.dash.cloudflare.com/) page.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/1.webp" alt="Screenshot of All Resource" />
 
@@ -93,8 +95,8 @@ Then, you will be prompted to add a hostname.
 5. **URL** - Enter **localhost:80** (this is very important).
 6. After filling in the details, click the **Save Tunnel** button.
 
-
 ## 2. Setup Encryption mode on Cloudflare
+
 To set up encryption on Cloudflare, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/15.webp" alt="Screenshot of All Resource" />
@@ -107,8 +109,8 @@ To set up encryption on Cloudflare, follow these steps:
 
 Choose **Full** as the encryption mode.
 
-
 ## 3. Setup Cloudflare Tunnel on Coolify
+
 To set up the tunnel on Coolify, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/7.webp" alt="Screenshot of All Resource" />
@@ -123,45 +125,46 @@ You will see many options to deploy a new app. Search for Cloudflared and click 
 
 Go to the **Environment Variables** page, enter your tunnel token, and deploy the Cloudflared app. This token was copied in [Step 1](#_1-create-a-cloudflare-tunnel)
 
-
 ## 4. Start Coolify Proxy
+
 To start the Coolify proxy, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/10.webp" alt="Screenshot of All Resource" />
 
-1. In the Coolify dashboard, go to the **Servers** page from the sidebar.  
-2. Select the server where coolify is running, then Click on the **Proxy** tab.  
-3. Open the **General** tab.  
-4. Click the **Start Proxy** button.  
+1. In the Coolify dashboard, go to the **Servers** page from the sidebar.
+2. Select the server where coolify is running, then Click on the **Proxy** tab.
+3. Open the **General** tab.
+4. Click the **Start Proxy** button.
 
 ::: success Tip  
-  The Coolify proxy is used to route traffic to apps running on your server. This eliminates the need to create new hostnames on the Cloudflare tunnel every time you deploy a new app.  
+ The Coolify proxy is used to route traffic to apps running on your server. This eliminates the need to create new hostnames on the Cloudflare tunnel every time you deploy a new app.  
 :::
 
 ## 5. Configure Your Resource to Use the Tunnel Domain
+
 Enter the domain you want to use for your resource/app and deploy your resource.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/11.webp" alt="Screenshot of All Resource" />
 
 ::: warning HEADS UP!  
-  You should enter the domain as **HTTP** because Cloudflare handles **HTTPS** and TLS terminations. If you use **HTTPS** for your resource, you may encounter a **TOO_MANY_REDIRECTS** error.  
+ You should enter the domain as **HTTP** because Cloudflare handles **HTTPS** and TLS terminations. If you use **HTTPS** for your resource, you may encounter a **TOO_MANY_REDIRECTS** error.
 
-  If your app requires **HTTPS** for features like cookies or login, follow the [Full TLS HTTPS Guide ↗](/knowledge-base/cloudflare/tunnels/full-tls) after completing this guide.  
+If your app requires **HTTPS** for features like cookies or login, follow the [Full TLS HTTPS Guide](/knowledge-base/cloudflare/tunnels/full-tls) after completing this guide.  
 :::
 
 **Congratulations**! You've successfully set up a resource that can be accessed by anyone on the internet your domain.
 
-
 ## How to use Mutiple Different Domains?
+
 You don't need to create new tunnels for each domain, just create a new hostname with the new domain and point it to the `localhost:80`.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/all-resource/12.webp" alt="Screenshot of All Resource" />
 
-
 ## Known issues and Solutions
-When you create a new public hostname in [Step 1](#_1-create-a-cloudflare-tunnel), Cloudflare will create a DNS record for the hostname. 
 
-However, if a DNS record for the hostname already exists, Cloudflare won’t create a new one. 
+When you create a new public hostname in [Step 1](#_1-create-a-cloudflare-tunnel), Cloudflare will create a DNS record for the hostname.
+
+However, if a DNS record for the hostname already exists, Cloudflare won’t create a new one.
 
 In this case, your app won’t work. To fix this issue, follow the steps below:
 

--- a/docs/knowledge-base/cloudflare/tunnels/full-tls.md
+++ b/docs/knowledge-base/cloudflare/tunnels/full-tls.md
@@ -4,35 +4,36 @@ description: "Configure end-to-end HTTPS for Coolify resources through Cloudflar
 ---
 
 # Full HTTPS/TLS Setup for All Resources
-When tunneling resources with Coolify through Cloudflare, Cloudflare typically handles HTTPS and TLS termination, while Coolify runs your resources over HTTP. 
 
-This setup works for most users, but some may face issues with URL mismatches, especially for apps that require HTTPS on Coolify to issue JWT tokens or handle callback URLs. 
+When tunneling resources with Coolify through Cloudflare, Cloudflare typically handles HTTPS and TLS termination, while Coolify runs your resources over HTTP.
+
+This setup works for most users, but some may face issues with URL mismatches, especially for apps that require HTTPS on Coolify to issue JWT tokens or handle callback URLs.
 
 This guide solves that issue by configuring your resources to run fully on HTTPS, bypassing Cloudflare's HTTPS handling and ensuring your app functions correctly with secure connections.
 
-
 ## Who this is for?
+
 This guide is ideal for users who:
 
 - Have followed our [Tunnel All Resources Using Cloudflare Tunnel](/knowledge-base/cloudflare/tunnels/all-resource) or [Tunnel Specific Resources Using Cloudflare Tunnel](/knowledge-base/cloudflare/tunnels/single-resource) guide.
 - Need their resources deployed with Coolify to run on HTTPS for applications requiring HTTPS for JWT issuance, callback functions, or similar features.
 
-
 ## Setup Requirements
+
 To follow this guide, you'll need:
 
 - A working Cloudflare tunnel setup as described in the previous guides.
 - A domain configured in Cloudflare to handle HTTP traffic and redirect to HTTPS.
 
-
 ## Before We Start
-- If your Coolify instance is on the same tunnel as the domain you want to configure, make sure you can access the Coolify Dashboard using the server IP and port (e.g., **203.0.113.1:8000**) before starting these steps. 
-- The default port is **8000**, but if you’ve changed or disabled it, ensure you can access the Coolify Dashboard through the new port or that port **8000** is re-enabled on the server.
 
+- If your Coolify instance is on the same tunnel as the domain you want to configure, make sure you can access the Coolify Dashboard using the server IP and port (e.g., **203.0.113.1:8000**) before starting these steps.
+- The default port is **8000**, but if you’ve changed or disabled it, ensure you can access the Coolify Dashboard through the new port or that port **8000** is re-enabled on the server.
 
 ---
 
 ### Quick Links to Important Sections:
+
 - [Create a Cloudflare Origin Certificate](#_1-create-a-cloudflare-origin-certificate)
 - [Add Origin Certificate to Your Server](#_2-add-origin-certificate-to-your-server)
 - [Configure Coolify to Use the Origin Certificate](#_3-configure-coolify-to-use-the-origin-certificate)
@@ -44,15 +45,15 @@ To follow this guide, you'll need:
 ---
 
 ::: warning Example Data
-  The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
-  
-  - **IPv4 Address of Origin Server:** 203.0.113.1
-  - **Domain Name:** shadowarcanist.com
-  - **Username:** shadowarcanist
-:::
+The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
 
+- **IPv4 Address of Origin Server:** 203.0.113.1
+- **Domain Name:** shadowarcanist.com
+- **Username:** shadowarcanist
+  :::
 
 ## 1. Create a Cloudflare Origin Certificate
+
 To create your Cloudflare Origin Certificate, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/1.webp" alt="Screenshot of Full Tls" />
@@ -69,14 +70,15 @@ You’ll be asked to choose a private key type, hostnames, and certificate valid
 2. Add the hostnames you want the certificate to cover.
 
 ::: warning HEADS UP!
-  - **`shadowarcanist.com`** will cover only the main domain.
-  - **`*.shadowarcanist.com`** will cover all subdomains.
-  
-  On Cloudflare’s free plan, wildcard certificates cover just one level of subdomains
-  
-  For example, it works for **`coolify.shadowarcanist.com`** but not **`www.coolify.shadowarcanist.com`**. 
-  
-  To cover multiple levels, you'll need to purchase the [Advanced Certificate Manager ↗](https://www.cloudflare.com/application-services/products/advanced-certificate-manager/)
+
+- **`shadowarcanist.com`** will cover only the main domain.
+- **`*.shadowarcanist.com`** will cover all subdomains.
+
+On Cloudflare’s free plan, wildcard certificates cover just one level of subdomains
+
+For example, it works for **`coolify.shadowarcanist.com`** but not **`www.coolify.shadowarcanist.com`**.
+
+To cover multiple levels, you'll need to purchase the [Advanced Certificate Manager](https://www.cloudflare.com/application-services/products/advanced-certificate-manager/)
 :::
 
 3. Set the certificate validity to **15 years**.
@@ -91,66 +93,79 @@ Your certificate will now be generated.
 
 Next, you'll add these to your server running Coolify and configure Coolify to use this certificate.
 
-
 ## 2. Add Origin Certificate to Your Server
+
 SSH into your server or use Coolify's terminal feature. For this guide, I’m using SSH:
+
 ```sh
 ssh shadowarcanist@203.0.113.1
 ```
 
 Once logged in, navigate to the Coolify proxy directory:
+
 ```sh
 cd /data/coolify/proxy
 ```
 
 Check if you have a **certs** folder:
+
 ```sh
 ls
 > acme.json  docker-compose.yml  dynamic
 ```
 
 If there’s no **certs** folder, create it:
+
 ```sh
 mkdir certs
 ```
 
 Verify it was created:
+
 ```sh
 ls
 > acme.json  certs docker-compose.yml  dynamic
 ```
 
 Now, navigate into the **certs** directory:
+
 ```sh
 cd certs
 ```
 
 Create two new files for the certificate and private key:
+
 ```sh
 touch shadowarcanist.cert shadowarcanist.key
 ```
 
 Verify the files were created:
+
 ```sh
 ls
 > shadowarcanist.cert shadowarcanist.key
 ```
 
 Open the **shadowarcanist.cert** file and paste the certificate from the Cloudflare dashboard:
+
 ```sh
-nano shadowarcanist.cert 
+nano shadowarcanist.cert
 ```
+
 Save and exit after pasting the certificate.
 
 Do the same for the **shadowarcanist.key** file and paste the private key:
+
 ```sh
-nano shadowarcanist.key 
+nano shadowarcanist.key
 ```
+
 Save and exit.
 
 Now the origin certificate is installed on your server.
 
 ## 3. Configure Coolify to Use the Origin Certificate
+
 Now, in your Coolify dashboard:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/12.webp" alt="Screenshot of Full Tls" />
@@ -166,37 +181,35 @@ You will now be prompted to enter the Dynamic Configuration.
 
 1. Choose a name for your configuration.
 2. Enter the following details in the configuration field:
+
 ```yaml
 tls:
   certificates:
-    -
-      certFile: /traefik/certs/shadowarcanist.cert
+    - certFile: /traefik/certs/shadowarcanist.cert
       keyFile: /traefik/certs/shadowarcanist.key
 ```
 
 ::: details Adding Multiple Certificates (click to view)
- 
+
 ```yaml
 tls:
   certificates:
-    -
-      certFile: /traefik/certs/shadowarcanist.cert
+    - certFile: /traefik/certs/shadowarcanist.cert
       keyFile: /traefik/certs/shadowarcanist.key
-    -
-      certFile: /traefik/certs/name2.cert
+    - certFile: /traefik/certs/name2.cert
       keyFile: /traefik/certs/name2.key
-    -
-      certFile: /traefik/certs/name3.cert
+    - certFile: /traefik/certs/name3.cert
       keyFile: /traefik/certs/name3.key
 ```
+
 :::
 
 3. Save the configuration
 
 From now on, Coolify will use the origin certificate for requests matching the hostname.
 
-
 ## 4. Setup Encryption mode on Cloudflare
+
 To set up encryption on Cloudflare, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/4.webp" alt="Screenshot of Full Tls" />
@@ -209,8 +222,8 @@ To set up encryption on Cloudflare, follow these steps:
 
 Choose **Full (Strict)** as the encryption mode.
 
-
 ## 5. Configure Tunnel to Use HTTPS
+
 To configure the tunnel for HTTPS, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/6.webp" alt="Screenshot of Full Tls" />
@@ -232,7 +245,6 @@ Next, update the hostnames as follows:
 5. Enter your root domain in the **Origin Server Name** field.
 6. Scroll down and click the **Save Hostname** button.
 
-
 ## 6. Configure Cloudflare to Always Use HTTPS
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/9.webp" alt="Screenshot of Full Tls" />
@@ -241,8 +253,8 @@ Next, update the hostnames as follows:
 2. Select **Edge Certificates**.
 3. Enable **Always Use HTTPS**.
 
-
 ## 7. Update URLs from HTTP to HTTPS
+
 Now, update all URLs from **HTTP** to **HTTPS** in Coolify, including resources and the instance domain on the settings page.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/full-tls/10.webp" alt="Screenshot of Full Tls" />

--- a/docs/knowledge-base/cloudflare/tunnels/overview.md
+++ b/docs/knowledge-base/cloudflare/tunnels/overview.md
@@ -4,28 +4,29 @@ description: "Connect Coolify resources securely without port forwarding using C
 ---
 
 # Cloudflare Tunnels
-[Cloudflare Tunnels ↗](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) allow you to securely expose your local server or applications to the internet without opening ports on your router. 
 
-This makes them a great option for hosting projects on devices like old laptops or Raspberry Pis.  
+[Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) allow you to securely expose your local server or applications to the internet without opening ports on your router.
 
+This makes them a great option for hosting projects on devices like old laptops or Raspberry Pis.
 
 ## Why Use Cloudflare Tunnels?
-- No need to open or forward ports on your device to the public internet.  
-- Simplifies routing and DNS configuration.  
-- Supports exposing a single application or multiple services.  
-- Hides your server's IP address by routing traffic through a Cloudflare Tunnel, showing only your domain.  
-- Works even if you have a dynamic IP (or) no public IP at all.  
-- Eliminates the hassle of managing and setting up SSL certificates.  
 
+- No need to open or forward ports on your device to the public internet.
+- Simplifies routing and DNS configuration.
+- Supports exposing a single application or multiple services.
+- Hides your server's IP address by routing traffic through a Cloudflare Tunnel, showing only your domain.
+- Works even if you have a dynamic IP (or) no public IP at all.
+- Eliminates the hassle of managing and setting up SSL certificates.
 
 ## When Not to Use Cloudflare Tunnels?
-- If you prefer direct access to your server without a proxy layer.  
-- If you're concerned about routing traffic through Cloudflare's servers.  
-- If you rely on additional firewall tools, as Cloudflare Tunnels bypass all firewall rules.  
-- If you need SSL certificates trusted by entities other than Cloudflare.  
 
+- If you prefer direct access to your server without a proxy layer.
+- If you're concerned about routing traffic through Cloudflare's servers.
+- If you rely on additional firewall tools, as Cloudflare Tunnels bypass all firewall rules.
+- If you need SSL certificates trusted by entities other than Cloudflare.
 
 ## Ways to Use Cloudflare Tunnels with Coolify
+
 You can set up Cloudflare Tunnels with Coolify in several ways, depending on your needs. Below are the available options, each linked to a detailed guide for easy setup:
 
 1. [All Resources](/knowledge-base/cloudflare/tunnels/all-resource) -> Use a tunnel for all resources deployed through Coolify. This is the **easiest** and **most recommended** way for beginners.
@@ -36,7 +37,6 @@ You can set up Cloudflare Tunnels with Coolify in several ways, depending on you
 
 4. [Full HTTPS/TLS](/knowledge-base/cloudflare/tunnels/full-tls) -> Setup always-on **HTTPS** for all domains and subdomains. Normally, Coolify uses **HTTP** while Cloudflare manages **HTTPS**. If certain apps require **HTTPS** directly on Coolify.
 
-
 ::: success Tip:
-  It’s highly recommended to go with the first option [All Resources](/knowledge-base/cloudflare/tunnels/all-resource) if you're new to Coolify and Cloudflare Tunnels, as it’s much easier to set up and manage.
+It’s highly recommended to go with the first option [All Resources](/knowledge-base/cloudflare/tunnels/all-resource) if you're new to Coolify and Cloudflare Tunnels, as it’s much easier to set up and manage.
 :::

--- a/docs/knowledge-base/cloudflare/tunnels/server-ssh.md
+++ b/docs/knowledge-base/cloudflare/tunnels/server-ssh.md
@@ -4,12 +4,13 @@ description: "Enable secure SSH access to Coolify servers via Cloudflare Tunnels
 ---
 
 # Server SSH Access via Cloudflare Tunnels
-Accessing your server using SSH over a Cloudflare Tunnel is a secure and easy way to connect to a remote server while keeping its IP address hidden. 
+
+Accessing your server using SSH over a Cloudflare Tunnel is a secure and easy way to connect to a remote server while keeping its IP address hidden.
 
 This guide explains how to set it up using Coolify's automated cloudflare tunnel installation.
 
-
 ## Who this is for?
+
 This setup is ideal for people who:
 
 - Want to keep their server's IP address private.
@@ -17,13 +18,13 @@ This setup is ideal for people who:
 - Don’t want to rely on static public IPs for accessing their remote server.
 - Don't have a static public IP for the server (only applies if you're doing the [manual setup](#manual-setup)).
 
-
 ## Before We Start
+
 - We assume you already have a server running Coolify and you are looking to set up a tunnel to connect a different server to Coolify.
 - If you are trying to set up a tunnel on the server where Coolify is running and you don’t have any other servers to connect, you don’t need a SSH tunnel. Coolify already has full root access to the server it’s running on, so there’s no need for an SSH tunnel in this case.
 
-
 ## How It Works?
+
 A simple high-level overview diagram to give you a visual idea of how this works:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/high-level-diagram.webp" alt="High Level Diagram configuration" />
@@ -31,25 +32,26 @@ A simple high-level overview diagram to give you a visual idea of how this works
 ---
 
 # Setup Methods
-There are two ways to set this up: automated and manual. 
 
-The main difference is that in the manual setup, you install cloudflared yourself, while in the automated setup, Coolify does it for you. 
+There are two ways to set this up: automated and manual.
+
+The main difference is that in the manual setup, you install cloudflared yourself, while in the automated setup, Coolify does it for you.
 
 Choose one of the links below for the setup guide:
 
 - [Automated](#automated-setup)
 - [Manual Setup](#manual-setup)
 
-
 ## Automated Setup
+
 To use Coolify's automated setup for a Cloudflare Tunnel:
 
 - Your remote server must have a **public IP address** and an **active SSH port** during the initial setup for Coolify to configure the tunnel. After setup, you can close all ports on the server.
-- If your server doesn’t have a public IP address, then this automated setup is **not for you**. Please follow the [Manual setup guide ↗](#manual-setup) instead.
+- If your server doesn’t have a public IP address, then this automated setup is **not for you**. Please follow the [Manual setup guide](#manual-setup) instead.
 - You need a domain that has it's **DNS managed by Cloudflare**.
 
-
 ### Quick Links to Important Sections:
+
 - [Create a Private SSH Key](#_1-create-a-private-ssh-key)
 - [Add Public Key to Your Server](#_2-add-public-key-to-your-server)
 - [Add your Server to Coolify](#_3-add-your-server-to-coolify)
@@ -60,17 +62,18 @@ To use Coolify's automated setup for a Cloudflare Tunnel:
 ---
 
 ::: warning Example Data
-  The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
-  
-  - **IPv4 Address of Remote Server:** 203.0.113.1
-  - **Domain Name:** shadowarcanist.com
-  - **Username:** root
-  - **SSH Port:** 22
-:::
+The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
+
+- **IPv4 Address of Remote Server:** 203.0.113.1
+- **Domain Name:** shadowarcanist.com
+- **Username:** root
+- **SSH Port:** 22
+  :::
 
 ---
 
 ## 1. Create a Private SSH Key
+
 To create a Private SSH Key, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-1.webp" alt="Automated 1 configuration" />
@@ -82,23 +85,25 @@ You will be prompted to choose a key type, along with providing a name and descr
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-2.webp" alt="Automated 2 configuration" />
 
-1. Click on Generate new **ED25519** or **RSA** button to generate a new SSH key. 
+1. Click on Generate new **ED25519** or **RSA** button to generate a new SSH key.
 2. Copy the public key and save it somewhere safe (you'll need it in the next step). Then, click Continue.
 
-
 ## 2. Add Public Key to Your Server
+
 SSH into the server you want to connect to Coolify:
+
 ```sh
   ssh root@203.0.113.1
 ```
 
 Once logged in, add your public key to the authorized keys file:
+
 ```sh
   $ echo "<PASTE YOUR PUBLIC KEY INSIDE OF THESE QUOTES>" >> ~/.ssh/authorized_keys
 ```
 
-
 ## 3. Add your Server to Coolify
+
 To add your server to Coolify, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-3.webp" alt="Automated 3 configuration" />
@@ -118,8 +123,8 @@ You will be prompted to enter details about your server. Make sure the informati
 6. **Private key** - Select the private key you created in [Step 1](#_1-create-a-private-ssh-key)
 7. After filling in the details, click the **Continue** button.
 
-
 ## 4. Validate your Server on Coolify
+
 To validate your server, simply click the **Validate Server & Install Docker Engine** button.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-5.webp" alt="Automated 5 configuration" />
@@ -130,9 +135,9 @@ Once the validation is completed, your server page will look like this:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-6.webp" alt="Automated 6 configuration" />
 
-
 ## 5. Create a Cloudflare Tunnel
-To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust ↗](https://one.dash.cloudflare.com/) page.
+
+To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust](https://one.dash.cloudflare.com/) page.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-7.webp" alt="Automated 7 configuration" />
 
@@ -169,8 +174,8 @@ Then, you will be prompted to add a hostname. This is where we expose our SSH tu
 5. **URL** - Enter **localhost:22** If your SSH port is different from 22, use that port instead.
 6. After filling in the details, click the **Save Tunnel** button.
 
-
 ## 6. Setup Cloudflare Tunnel on Coolify
+
 To set up the tunnel on Coolify, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/automated-13.webp" alt="Automated 13 configuration" />
@@ -203,18 +208,18 @@ You can now block your SSH port on the server if you wish.
 **Congratulations**! You've successfully set up a server that can be accessed by Coolify over SSH using Cloudflare tunnels via your domain.
 
 ::: danger HEADS UP!
-  **The steps above show how to do the automated setup. Below are the steps for the manual setup.**
+**The steps above show how to do the automated setup. Below are the steps for the manual setup.**
 :::
 
-
 ## Manual Setup
+
 To manually setup Cloudflare Tunnel:
 
 - You need access to your remote server to install cloudflared (a public IP for your server is not required).
 - You need a domain that has it's **DNS managed by Cloudflare**.
 
-
 ### Quick Links to Important Sections:
+
 - [Create a Private SSH Key](#_1-create-a-private-ssh-key-1)
 - [Add Public Key to Your Server](#_2-add-public-key-to-your-server-1)
 - [Create a Cloudflare Tunnel](#_3-create-a-cloudflare-tunnel)
@@ -225,17 +230,18 @@ To manually setup Cloudflare Tunnel:
 ---
 
 ::: warning Example Data
-  The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
-  
-  - **IPv4 Address of Remote Server:** 203.0.113.1
-  - **Domain Name:** shadowarcanist.com
-  - **Username:** root
-  - **SSH Port:** 22
-:::
+The following data is used as an example in this guide. Please replace it with your actual data when following the steps:
+
+- **IPv4 Address of Remote Server:** 203.0.113.1
+- **Domain Name:** shadowarcanist.com
+- **Username:** root
+- **SSH Port:** 22
+  :::
 
 ---
 
 ## 1. Create a Private SSH Key
+
 To create a Private SSH Key, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-1.webp" alt="Manual 1 configuration" />
@@ -247,25 +253,28 @@ You will be prompted to choose a key type, along with providing a name and descr
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-2.webp" alt="Manual 2 configuration" />
 
-1. Click on Generate new **ED25519** or **RSA** button to generate a new SSH key. 
+1. Click on Generate new **ED25519** or **RSA** button to generate a new SSH key.
 2. Copy the public key and save it somewhere safe (you'll need it in the next step). Then, click Continue.
 
-
 ## 2. Add Public Key to Your Server
+
 SSH into the server you want to connect to Coolify:
+
 ```sh
   ssh root@203.0.113.1
 ```
+
 This server can be on your local network without a public IP address. All you need is SSH access to the terminal to run commands.
 
 Once logged in, add your public key to the authorized keys file:
+
 ```sh
   $ echo "<PASTE YOUR PUBLIC KEY INSIDE OF THESE QUOTES>" >> ~/.ssh/authorized_keys
 ```
 
-
 ## 3. Create a Cloudflare Tunnel
-To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust ↗](https://one.dash.cloudflare.com/) page.
+
+To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust](https://one.dash.cloudflare.com/) page.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-3.webp" alt="Manual 3 configuration" />
 
@@ -302,8 +311,8 @@ Then, you will be prompted to add a hostname. This is where we expose our SSH tu
 5. **URL** - Enter **localhost:22** If your SSH port is different from 22, use that port instead.
 6. After filling in the details, click the **Save Tunnel** button.
 
-
 ## 4. Add your Server to Coolify
+
 To add your server to Coolify, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-9.webp" alt="Manual 9 configuration" />
@@ -323,8 +332,8 @@ You will be prompted to enter details about your server. Make sure the informati
 6. **Private key** - Select the private key you created in [Step 1](#_1-create-a-private-ssh-key-1)
 7. After filling in the details, click the **Continue** button.
 
-
 ## 5. Validate your Server on Coolify
+
 To validate your server, simply click the **Validate Server & Install Docker Engine** button.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-11.webp" alt="Manual 11 configuration" />
@@ -335,8 +344,8 @@ Once the validation is completed, your server page will look like this:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-12.webp" alt="Manual 12 configuration" />
 
-
 ## 6. Setup Cloudflare Tunnel on Coolify
+
 To set up the tunnel on Coolify, follow these steps:
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/server-ssh/manual-13.webp" alt="Manual 13 configuration" />

--- a/docs/knowledge-base/cloudflare/tunnels/single-resource.md
+++ b/docs/knowledge-base/cloudflare/tunnels/single-resource.md
@@ -20,14 +20,14 @@ This setup is ideal for people who:
 
 To follow this guide, you'll need:
 
-- A free [Cloudflare ↗](https://cloudflare.com) account.
+- A free [Cloudflare](https://cloudflare.com) account.
 - You need a domain that has it's **DNS managed by Cloudflare**.
 - Your Resource has to be deployed and managed with Coolify.
 
 ## Before We Start
 
 - We assume you have Coolify running and an app already deployed.
-- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide ↗](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
+- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
 
 ## How It Works?
 
@@ -70,7 +70,7 @@ To setup your app for tunneling, follow these steps:
 
 ## 2. Create a Cloudflare Tunnel
 
-To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust ↗](https://one.dash.cloudflare.com/) page.
+To create a Cloudflare Tunnel, first log in to your Cloudflare account and go to the [Zero Trust](https://one.dash.cloudflare.com/) page.
 
 <ZoomableImage src="/docs/images/knowledge-base/cf-tunnel/single-resource/2.webp" alt="Screenshot of Single Resource" />
 

--- a/docs/knowledge-base/domains.md
+++ b/docs/knowledge-base/domains.md
@@ -23,7 +23,7 @@ When you enter a domain using the `https://` protocol (for example, `https://exa
 
 1. **Automatic Proxy Configuration** - Coolify automatically applies the necessary configuration to your reverse proxy (Traefik or Caddy) to serve your application over HTTPS.
 
-2. **Certificate Issuance** - The proxy automatically starts the process to request and install SSL certificates from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io).
+2. **Certificate Issuance** - The proxy automatically starts the process to request and install SSL certificates from [Let's Encrypt](https://letsencrypt.org?utm_source=coolify.io).
 
 3. **Automatic Renewal** - Certificates are automatically renewed before they expire. Let's Encrypt certificates are valid for 90 days and Coolify handles renewals seamlessly.
 
@@ -33,7 +33,7 @@ You don't need to do anything special to enable HTTPS. Simply use `https://` whe
 
 ### Self-Signed Certificates
 
-If automatic certificate issuance from [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) fails, the Coolify Proxy will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
+If automatic certificate issuance from [Let's Encrypt](https://letsencrypt.org?utm_source=coolify.io) fails, the Coolify Proxy will provide a self-signed certificate to keep your application accessible. This means your application will still be reachable, but browsers will show a security warning.
 
 ::: warning TROUBLESHOOTING
 If you see a certificate warning in your browser or your application shows a self-signed certificate, see the [Let's Encrypt Not Working](/troubleshoot/dns-and-domains/lets-encrypt-not-working) troubleshooting guide for detailed solutions.

--- a/docs/knowledge-base/proxy/caddy/basic-auth.md
+++ b/docs/knowledge-base/proxy/caddy/basic-auth.md
@@ -5,17 +5,18 @@ description: "Add password protection to Coolify applications with Caddy basic a
 
 # Caddy Basic Auth
 
-Basic authentication provides an extra layer of security for your applications by requiring a username and password to access protected resources. 
+Basic authentication provides an extra layer of security for your applications by requiring a username and password to access protected resources.
 
 With Coolify, you can easily integrate basic auth into your Caddy web server configuration.
 
 ## Why Use Basic Auth with Caddy?
+
 1. **Enhanced Security:** Adds an extra barrier to prevent unauthorized access.
 2. **Simplicity:** Straightforward configuration that integrates directly into your Caddy setup.
 3. **Flexibility:** Configure different credentials for different services as needed.
 
-
 ## 1. Generate a Hashed Password
+
 For Caddy to validate credentials securely, your password must be hashed using Caddy's built-in tool. The basic auth credential is set as:
 
 ```sh
@@ -24,24 +25,27 @@ caddy_0.basicauth.<username>="<hashed_password>"
 
 The `<hashed_password>` **must be generated with the Caddy CLI** using the `caddy hash-password` command.
 
-
 ### How to Generate a Hashed Password
+
 1. Open your terminal.
 2. Run the following command:
+
    ```sh
    caddy hash-password --plaintext "your_plaintext_password"
    ```
+
    Replace `"your_plaintext_password"` with your actual password.
 
 3. The output will be a hashed password that you can use directly in your Caddy configuration.
 
-For more details and advanced options (like choosing a different algorithm), refer to the [Caddy CLI documentation ↗](https://caddyserver.com/docs/command-line#caddy-hash-password?utm_source=coolify.io).
-
+For more details and advanced options (like choosing a different algorithm), refer to the [Caddy CLI documentation](https://caddyserver.com/docs/command-line#caddy-hash-password?utm_source=coolify.io).
 
 ## 2. Configure Basic Auth in Coolify
+
 Once you have your hashed password, integrate it into your Coolify configuration.
 
 1. **Add the Basic Auth Entry:**
+
    - Add the following line to the Caddyfile of the application where you want to enable basic authentication:
      ```sh
      caddy_0.basicauth.<username>="<hashed_password>"
@@ -52,9 +56,8 @@ Once you have your hashed password, integrate it into your Coolify configuration
    - Save your configuration changes.
    - Restart your application to apply the new settings.
 
-
 ::: warning Note
-Make sure that your hashed password is generated **only** using the Caddy CLI. 
+Make sure that your hashed password is generated **only** using the Caddy CLI.
 
 Using an unrecognized hash method may result in authentication failures.
 :::

--- a/docs/knowledge-base/proxy/caddy/overview.md
+++ b/docs/knowledge-base/proxy/caddy/overview.md
@@ -4,31 +4,31 @@ description: "Use Caddy reverse proxy with Coolify for automatic SSL certificate
 ---
 
 # Caddy Proxy
-[Caddy ↗](https://caddyserver.com/) is an easy-to-use, open-source web server and reverse proxy that automatically manages SSL/TLS certificates. It's known for its simplicity and automation, especially when it comes to securing your websites.  
 
-While [Traefik ↗](https://traefik.io/) is the default reverse proxy used in Coolify, Caddy is another option you can explore if you prefer its simplicity or unique features.
+[Caddy](https://caddyserver.com/) is an easy-to-use, open-source web server and reverse proxy that automatically manages SSL/TLS certificates. It's known for its simplicity and automation, especially when it comes to securing your websites.
 
+While [Traefik](https://traefik.io/) is the default reverse proxy used in Coolify, Caddy is another option you can explore if you prefer its simplicity or unique features.
 
-## Why Use Caddy?  
-- Caddy automatically generates and renews SSL certificates for your sites, making it extremely easy to secure your applications.  
-- Caddy uses a simple, declarative configuration file (Caddyfile), making it beginner-friendly.  
-- Caddy comes with features like reverse proxying, load balancing, HTTP/2, and more out of the box without needing extra plugins.  
-- If you’re looking for a proxy that “just works” with minimal configuration, Caddy can be a great choice.  
+## Why Use Caddy?
 
+- Caddy automatically generates and renews SSL certificates for your sites, making it extremely easy to secure your applications.
+- Caddy uses a simple, declarative configuration file (Caddyfile), making it beginner-friendly.
+- Caddy comes with features like reverse proxying, load balancing, HTTP/2, and more out of the box without needing extra plugins.
+- If you’re looking for a proxy that “just works” with minimal configuration, Caddy can be a great choice.
 
-## When Not to Use Caddy?  
-- If you need advanced proxying features like dynamic routing, middleware, or complex load balancing, Traefik might be a better choice.  
-- Since Coolify primarily uses Traefik, certain configurations in Caddy might require additional manual setup.  
+## When Not to Use Caddy?
 
+- If you need advanced proxying features like dynamic routing, middleware, or complex load balancing, Traefik might be a better choice.
+- Since Coolify primarily uses Traefik, certain configurations in Caddy might require additional manual setup.
 
-## A Note from the Coolify Team  
-While Caddy is a fantastic tool for certain use cases, **we highly recommend** using **Traefik** over Caddy for most Coolify setups. 
+## A Note from the Coolify Team
 
-The [Core team](/get-started/team) primarily uses Traefik, and it is the default reverse proxy configured within Coolify.  
+While Caddy is a fantastic tool for certain use cases, **we highly recommend** using **Traefik** over Caddy for most Coolify setups.
 
-Only consider using Caddy if you're familiar with it or need specific features that Traefik cannot provide.  
+The [Core team](/get-started/team) primarily uses Traefik, and it is the default reverse proxy configured within Coolify.
 
-At the moment, we do not have detailed guides for Caddy because it is not our primary reverse proxy, and using it may require more manual configuration.  
+Only consider using Caddy if you're familiar with it or need specific features that Traefik cannot provide.
+
+At the moment, we do not have detailed guides for Caddy because it is not our primary reverse proxy, and using it may require more manual configuration.
 
 If you choose to use Caddy, please make sure you are comfortable with configuring it yourself.
-

--- a/docs/knowledge-base/proxy/traefik/overview.md
+++ b/docs/knowledge-base/proxy/traefik/overview.md
@@ -5,7 +5,7 @@ description: "Configure Traefik reverse proxy in Coolify with dynamic routing, S
 
 # Traefik Proxy
 
-[Traefik ↗](https://traefik.io/) is a modern, open-source reverse proxy and load balancer designed to handle incoming requests and route them to the appropriate services. It’s widely used in the container ecosystem, making it a perfect fit for projects running on Coolify.
+[Traefik](https://traefik.io/) is a modern, open-source reverse proxy and load balancer designed to handle incoming requests and route them to the appropriate services. It’s widely used in the container ecosystem, making it a perfect fit for projects running on Coolify.
 
 By default, Coolify uses Traefik as its proxy, enabling easy management of routing, SSL certificates, and more, without requiring deep technical expertise.
 
@@ -13,14 +13,14 @@ By default, Coolify uses Traefik as its proxy, enabling easy management of routi
 
 - Dynamically manages routing between your apps and the internet.
 - Integrates seamlessly with container orchestrators like Docker or Kubernetes.
-- Simplifies SSL/TLS certificate management, including support for [Let's Encrypt ↗](https://letsencrypt.org/).
+- Simplifies SSL/TLS certificate management, including support for [Let's Encrypt](https://letsencrypt.org/).
 - Offers advanced features like load balancing and middleware for fine-grained control.
 - Comes with a built-in dashboard for monitoring routes and configurations.
 
 ## When Not to Use Traefik?
 
 - If you need complete control over every aspect of your reverse proxy.
-- If you prefer using another reverse proxy solution like [NGINX ↗](https://nginx.org/en/).
+- If you prefer using another reverse proxy solution like [NGINX](https://nginx.org/en/).
 - If you have highly customized or complex routing rules that Traefik might not fully support.
 
 ## Ways to Use Traefik with Coolify

--- a/docs/services/actualbudget.md
+++ b/docs/services/actualbudget.md
@@ -6,14 +6,16 @@ description: "Host Actual Budget on Coolify for privacy-focused envelope budgeti
 <ZoomableImage src="/docs/images/services/actual-budget-logo.webp" alt="Actual Budget Logo logo" />
 
 ## What is Actual Budget?
+
 Actual Budget is a super fast and privacy-focused app for managing your finances. At its heart is the well proven and much loved Envelope Budgeting methodology.
 
 You own your data and can do whatever you want with it. Featuring multi-device sync, optional end-to-end encryption and so much more.
 
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/actual-budget-screenshot.webp" alt="Actualbudget interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://actualbudget.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/actualbudget/actual?utm_source=coolify.io)
+- [The official website](https://actualbudget.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/actualbudget/actual?utm_source=coolify.io)

--- a/docs/services/affine.md
+++ b/docs/services/affine.md
@@ -5,18 +5,17 @@ description: "Deploy AFFiNE workspace on Coolify combining docs, whiteboards, an
 
 <ZoomableImage src="/docs/images/services/affine.webp" alt="Affine Logo logo" />
 
-
 ## What is Affine?
+
 AFFiNE is a workspace with fully merged docs, whiteboards and databases.
 
 Get more things done, your creativity isn’t monotone.
 
-
 ## Screenshots
-<ZoomableImage src="/docs/images/services/affine-screenshots.gif" alt="Affine interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/affine-screenshots.gif" alt="Affine interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://affine.pro/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/toeverything/AFFiNE?utm_source=coolify.io)
+- [The official website](https://affine.pro/?utm_source=coolify.io)
+- [GitHub](https://github.com/toeverything/AFFiNE?utm_source=coolify.io)

--- a/docs/services/anythingllm.md
+++ b/docs/services/anythingllm.md
@@ -94,12 +94,12 @@ AnythingLLM is the easiest to use, all-in-one AI application that can do RAG, AI
 
 ![AnythingLLM](/images/services/anythingllm.gif)
 
-<!-- <TabBlock   
-  :tabs="frontmatter.tabs" 
-  :compose="frontmatter.compose" 
+<!-- <TabBlock
+  :tabs="frontmatter.tabs"
+  :compose="frontmatter.compose"
 /> -->
 
 ## Links
 
-- [The official website ›](https://www.anythingllm.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/Mintplex-Labs/anything-llm?utm_source=coolify.io)
+- [The official website](https://www.anythingllm.com?utm_source=coolify.io)
+- [GitHub](https://github.com/Mintplex-Labs/anything-llm?utm_source=coolify.io)

--- a/docs/services/apache-superset.md
+++ b/docs/services/apache-superset.md
@@ -23,16 +23,15 @@ After deploying the template, you will need to initialise the database and creat
 
 2. Run one of the commands below, noting the `-` symbol:
 
-    ```bash
-    # Basic initialisation
-    superset-init
+   ```bash
+   # Basic initialisation
+   superset-init
 
-    # Alternatively, to also load demo data, use
-    superset-demo
-    ```
+   # Alternatively, to also load demo data, use
+   superset-demo
+   ```
 
-    the source code for these scripts are available [here](https://github.com/amancevice/docker-superset/tree/main/bin).
-
+   the source code for these scripts are available [here](https://github.com/amancevice/docker-superset/tree/main/bin).
 
 3. Answer all questions in the prompts
 
@@ -50,6 +49,6 @@ This python config file can be edited using Coolify's UI by navigating to your s
 
 ## Links
 
-- [Official Website ›](https://superset.apache.org)
-- [GitHub ›](https://github.com/apache/superset)
-- [Github Unofficial Docker Image >](https://github.com/amancevice/docker-superset)
+- [Official Website](https://superset.apache.org)
+- [GitHub](https://github.com/apache/superset)
+- [Github Unofficial Docker Image](https://github.com/amancevice/docker-superset)

--- a/docs/services/apprise-api.md
+++ b/docs/services/apprise-api.md
@@ -4,6 +4,7 @@ description: "Host Apprise API on Coolify to send push notifications to 100+ ser
 ---
 
 # What is Apprise API?
+
 [Apprise-api](https://github.com/caronc/apprise-api) Takes advantage of [Apprise](https://github.com/caronc/apprise) through your network with a user-friendly API.
 
 - Send notifications to more than 100 services.
@@ -13,16 +14,15 @@ description: "Host Apprise API on Coolify to send push notifications to 100+ ser
 
 Apprise API was designed to easily fit into existing (and new) eco-systems that are looking for a simple notification solution.
 
-
 ## Screenshots
+
 ![](https://raw.githubusercontent.com/caronc/apprise-api/master/Screenshot-2.png)
 
 <br />
 
 ![](https://raw.githubusercontent.com/caronc/apprise-api/master/Screenshot-3.png)
 
-
 ## Links
 
-- [The official website ›](https://hub.docker.com/r/caronc/apprise/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/caronc/apprise-api?utm_source=coolify.io)
+- [The official website](https://hub.docker.com/r/caronc/apprise/?utm_source=coolify.io)
+- [GitHub](https://github.com/caronc/apprise-api?utm_source=coolify.io)

--- a/docs/services/appsmith.md
+++ b/docs/services/appsmith.md
@@ -4,17 +4,19 @@ description: "Build internal tools on Coolify with Appsmith's low-code platform 
 ---
 
 # Appsmith
+
 ![Appsmith](https://raw.githubusercontent.com/appsmithorg/appsmith/release/static/images/appsmith-in-100-seconds.png)
 
-
 ## What is Appsmith
-Organizations build internal applications such as dashboards, database GUIs, admin panels, approval apps, customer support tools, etc. to help improve their business operations. 
 
-Appsmith is an open-source developer tool that enables the rapid development of these applications. You can drag and drop pre-built widgets to build UI. 
+Organizations build internal applications such as dashboards, database GUIs, admin panels, approval apps, customer support tools, etc. to help improve their business operations.
+
+Appsmith is an open-source developer tool that enables the rapid development of these applications. You can drag and drop pre-built widgets to build UI.
 
 Connect securely to your databases & APIs using its datasources. Write business logic to read & write data using queries & JavaScript.
 
 ## Why Appsmith
+
 Appsmith makes it easy to build a UI that talks to any datasource. You can create anything from simple CRUD apps to complicated multi-step workflows with a few simple steps:
 
 - Connect Datasource: Integrate with a database or API. Appsmith supports the most popular databases and REST APIs.
@@ -22,20 +24,20 @@ Appsmith makes it easy to build a UI that talks to any datasource. You can creat
 - Write Logic: Express your business logic using queries and JavaScript anywhere in the editor.
 - Collaborate, Deploy, Share: Appsmith supports version control using Git to build apps in collaboration using branches to track and roll back changes. Deploy the app and share it with other users.
 
-
 ## Learning Resources
+
 - [Documentation](https://docs.appsmith.com?utm_source=coolify.io)
 - [Tutorials](https://docs.appsmith.com/getting-started/tutorials?utm_source=coolify.io)
 - [Videos](https://www.youtube.com/appsmith?utm_source=coolify.io)
 - [Templates](https://www.appsmith.com/templates?utm_source=coolify.io)
 
-
 ## Need Help?
+
 - [Discord](https://discord.gg/rBTTVJp?utm_source=coolify.io)
 - [Community Portal](https://community.appsmith.com/?utm_source=coolify.io)
 - [support@appsmith.com](mailto:support@appsmith.com)
 
-
 ## Links
-- [The official website ›](https://www.appsmith.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/appsmithorg/appsmith?utm_source=coolify.io)
+
+- [The official website](https://www.appsmith.com?utm_source=coolify.io)
+- [GitHub](https://github.com/appsmithorg/appsmith?utm_source=coolify.io)

--- a/docs/services/appwrite.md
+++ b/docs/services/appwrite.md
@@ -716,7 +716,7 @@ description: "Deploy Appwrite BaaS on Coolify for authentication, databases, sto
 #       image: redis:7.2.4-alpine
 #       container_name: appwrite-redis
 #       command: >
-#         redis-server --maxmemory            512mb --maxmemory-policy    
+#         redis-server --maxmemory            512mb --maxmemory-policy
 #         allkeys-lru --maxmemory-samples    5
 #       volumes:
 #         - appwrite-redis:/data:rw
@@ -734,8 +734,8 @@ description: "Deploy Appwrite BaaS on Coolify for authentication, databases, sto
 #     appwrite-config: null
 ---
 
-
 # Appwrite
+
 ![Appwrite](https://raw.githubusercontent.com/appwrite/appwrite/main/public/images/banner.png)
 
 ## What is Appwrite?
@@ -747,5 +747,5 @@ file management, image manipulation, Cloud Functions, and [more services](https:
 
 ## Links
 
-- [The official website ›](https://appwrite.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/appwrite/appwrite?utm_source=coolify.io)
+- [The official website](https://appwrite.io?utm_source=coolify.io)
+- [GitHub](https://github.com/appwrite/appwrite?utm_source=coolify.io)

--- a/docs/services/argilla.md
+++ b/docs/services/argilla.md
@@ -6,13 +6,14 @@ description: "Host Argilla on Coolify for collaborative AI dataset creation, ann
 <ZoomableImage src="/docs/images/services/argilla.svg" alt="Argilla dashboard" />
 
 ## What is Argilla?
+
 Argilla is a collaboration tool for AI engineers and domain experts to build high-quality datasets.
 
-
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/argilla.webp" alt="Argilla dashboard" />
 
 ## Links
 
-- [The official website ›](https://argilla.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/argilla-io/argilla?utm_source=coolify.io)
+- [The official website](https://argilla.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/argilla-io/argilla?utm_source=coolify.io)

--- a/docs/services/authentik.md
+++ b/docs/services/authentik.md
@@ -6,18 +6,19 @@ description: "Run Authentik identity provider on Coolify with SSO, LDAP, OAuth2,
 ![Authentik](https://goauthentik.io/img/icon_top_brand_colour.svg)
 
 ## What is authentik?
-Authentik is an open-source Identity Provider that emphasizes flexibility and versatility. It can be seamlessly integrated into existing environments to support new protocols. 
+
+Authentik is an open-source Identity Provider that emphasizes flexibility and versatility. It can be seamlessly integrated into existing environments to support new protocols.
 
 Authentik is also a great solution for implementing sign-up, recovery, and other similar features in your application, saving you the hassle of dealing with them.
 
-
 ## Screenshots
+
 | Light                                                       | Dark                                                       |
 | ----------------------------------------------------------- | ---------------------------------------------------------- |
 | ![](https://docs.goauthentik.io/img/screen_apps_light.jpg)  | ![](https://docs.goauthentik.io/img/screen_apps_dark.jpg)  |
 | ![](https://docs.goauthentik.io/img/screen_admin_light.jpg) | ![](https://docs.goauthentik.io/img/screen_admin_dark.jpg) |
 
-
 ## Links
-- [The official website ›](https://goauthentik.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/goauthentik/authentik?utm_source=coolify.io)
+
+- [The official website](https://goauthentik.io?utm_source=coolify.io)
+- [GitHub](https://github.com/goauthentik/authentik?utm_source=coolify.io)

--- a/docs/services/babybuddy.md
+++ b/docs/services/babybuddy.md
@@ -3,26 +3,26 @@ title: "BabyBuddy"
 description: "Track baby care on Coolify with Baby Buddy featuring feeding, diaper changes, sleep schedules, growth charts, and caregiver coordination."
 ---
 
-
 ![BabyBuddy](https://raw.githubusercontent.com/babybuddy/babybuddy/master/babybuddy/static_src/logo/icon.png)
 
-
 ## What is BabyBuddy?
+
 A buddy for babies! Helps caregivers track sleep, feedings, diaper changes, tummy time and more to learn about and predict baby's needs without (_as much_) guess work.
 
-
 ## Screenshots
+
 ![Baby Buddy desktop view](https://raw.githubusercontent.com/babybuddy/babybuddy/master/screenshot.png)
 ![Baby Buddy mobile views](https://raw.githubusercontent.com/babybuddy/babybuddy/master/screenshot_mobile.png)
 
-
 ## Demo
+
 A [demo of Baby Buddy](https://demo.baby-buddy.net?utm_source=coolify.io) is available. The demo instance
 resets every hour. Login credentials are:
+
 - Username: `admin`
 - Password: `admin`
 
-
 ## Links
-- [The official website ›](https://docs.baby-buddy.net?utm_source=coolify.io)
-- [GitHub ›](https://github.com/babybuddy/babybuddy?utm_source=coolify.io)
+
+- [The official website](https://docs.baby-buddy.net?utm_source=coolify.io)
+- [GitHub](https://github.com/babybuddy/babybuddy?utm_source=coolify.io)

--- a/docs/services/beszel.md
+++ b/docs/services/beszel.md
@@ -6,8 +6,8 @@ description: "Deploy Beszel lightweight server monitoring on Coolify with real-t
 <ZoomableImage src="/docs/images/services/beszel.svg" alt="Beszel dashboard" />
 
 ## What is Beszel?
-Lightweight server monitoring hub with historical data, docker stats, and alerts.
 
+Lightweight server monitoring hub with historical data, docker stats, and alerts.
 
 ## Setup
 
@@ -21,4 +21,4 @@ Lightweight server monitoring hub with historical data, docker stats, and alerts
 
 ## Links
 
-- [GitHub ›](https://github.com/henrygd/beszel)
+- [GitHub](https://github.com/henrygd/beszel)

--- a/docs/services/bluesky-pds.md
+++ b/docs/services/bluesky-pds.md
@@ -19,11 +19,11 @@ Pdsadmin requires you to have https in your Bluesky PDS, make sure you have set 
 
 To create an account and start using your PDS, you can use the following pdsadmin commnands in the Terminal tab of the Coolify UI:
 
-```bash 
+```bash
 pdsadmin create-invite-code
 ```
 
-or 
+or
 
 ```bash
 pdsadmin account create <email> <handle>
@@ -53,5 +53,5 @@ And that's it, your PDS should be ready for you to use, it will work like any ot
 
 ## Links
 
-- [The official website ›](https://blueskyweb.xyz?utm_source=coolify.io)
-- [GitHub ›](https://github.com/bluesky-social/pds?utm_source=coolify.io)
+- [The official website](https://blueskyweb.xyz?utm_source=coolify.io)
+- [GitHub](https://github.com/bluesky-social/pds?utm_source=coolify.io)

--- a/docs/services/browserless.md
+++ b/docs/services/browserless.md
@@ -3,14 +3,14 @@ title: "Browserless"
 description: "Run Browserless on Coolify for headless Chrome automation, web scraping, PDF generation, and screenshot services via simple REST API."
 ---
 
-
 <ZoomableImage src="/docs/images/services/browserless.webp" alt="Browserless dashboard" />
 
 ## What is Browserless
+
 Browserless is a platform that provides headless browser automation and management services. It allows developers to run automated browser tasks without the need for manual intervention, making it ideal for web scraping, testing, and rendering tasks.
 
-
 ## Example use cases
+
 - Web Scraping: Automate the collection of data from websites, such as product prices, news articles, or social media content, without worrying about CAPTCHAs, JavaScript rendering, or rate limits.
 
 - Automated Testing: Run browser-based tests for web applications using tools like Puppeteer or Selenium to check functionality, compatibility, and performance across different browsers.
@@ -21,8 +21,8 @@ Browserless is a platform that provides headless browser automation and manageme
 
 - SEO Audits: Use Browserless to run scripts that crawl your website, analyzing metadata, tags, and other factors that impact SEO, ensuring your site follows best practices.
 
-
 ## Key Features
+
 - Headless Browser Automation: Supports running headless browsers, automating tasks with Puppeteer, Playwright, and Selenium without manual browser operation.
 
 - Cloud-Based Infrastructure: Run scripts in the cloud, reducing the need to manage your own browser environments and infrastructure.
@@ -33,14 +33,14 @@ Browserless is a platform that provides headless browser automation and manageme
 
 - Logging & Debugging Tools: Detailed logging and debugging tools for tracking and troubleshooting automated browser sessions.
 
-
 ## Images
+
 ![templates](https://cdn.prod.website-files.com/65cb4923a3a6b08fe1124094/6601a7a5b8508b353addd84f_social-preview.jpg)
 
-
 ## Links
-- [The official website ›](https://www.browserless.io?utm_source=coolify.io)
-- [Documentation ›](https://docs.browserless.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/browserless?utm_source=coolify.io)
-- [Api Documentation ›](https://docs.browserless.io/docs/api.html?utm_source=coolify.io)
-- [Pricing ›](https://www.browserless.io/pricing?utm_source=coolify.io)
+
+- [The official website](https://www.browserless.io?utm_source=coolify.io)
+- [Documentation](https://docs.browserless.io?utm_source=coolify.io)
+- [GitHub](https://github.com/browserless?utm_source=coolify.io)
+- [Api Documentation](https://docs.browserless.io/docs/api.html?utm_source=coolify.io)
+- [Pricing](https://www.browserless.io/pricing?utm_source=coolify.io)

--- a/docs/services/budge.md
+++ b/docs/services/budge.md
@@ -3,8 +3,8 @@ title: "BudgE"
 description: "Manage finances with Budge on Coolify offering budget tracking, expense categorization, financial goals, and spending insights for personal finance."
 ---
 
-
 ## What is BudgE?
+
 BudgE (pronounced "budgie", like the bird) is an open source "budgeting with envelopes" personal finance app, taking inspiration from other tools such as [Aspire Budgeting](https://www.aspirebudget.com?utm_source=coolify.io), [budgetzero](https://budgetzero.io?utm_source=coolify.io), and [Buckets](https://www.budgetwithbuckets.com/?utm_source=coolify.io).
 
 ## Current Features
@@ -22,7 +22,6 @@ BudgE (pronounced "budgie", like the bird) is an open source "budgeting with env
 
 ![screenshot1](https://raw.githubusercontent.com/linuxserver/budge/main/images/budget.png)
 
-
 ![screenshot2](https://raw.githubusercontent.com/linuxserver/budge/main/images/account.png)
 
 ## Support
@@ -31,4 +30,4 @@ BudgE (pronounced "budgie", like the bird) is an open source "budgeting with env
 
 ## Links
 
-- [GitHub ›](https://github.com/linuxserver/budge?utm_source=coolify.io)
+- [GitHub](https://github.com/linuxserver/budge?utm_source=coolify.io)

--- a/docs/services/bugsink.md
+++ b/docs/services/bugsink.md
@@ -10,9 +10,9 @@ description: "Deploy Bugsink error tracking on Coolify for application monitorin
 [Bugsink](https://www.bugsink.com/?utm_source=coolify.io) offers [error tracking](https://www.bugsink.com/error-tracking/?utm_source=coolify.io) for your applications with
 full control through self-hosting.
 
-* [Built to self-host](https://www.bugsink.com/built-to-self-host/?utm_source=coolify.io)
-* [Sentry-SDK compatible](https://www.bugsink.com/sentry-sdk-compatible/?utm_source=coolify.io)
-* [Scalable and reliable](https://www.bugsink.com/scalable-and-reliable/?utm_source=coolify.io)
+- [Built to self-host](https://www.bugsink.com/built-to-self-host/?utm_source=coolify.io)
+- [Sentry-SDK compatible](https://www.bugsink.com/sentry-sdk-compatible/?utm_source=coolify.io)
+- [Scalable and reliable](https://www.bugsink.com/scalable-and-reliable/?utm_source=coolify.io)
 
 ## Screenshots
 
@@ -20,5 +20,5 @@ full control through self-hosting.
 
 ## Links
 
-- [The official website ›](https://www.bugsink.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/bugsink/bugsink/?utm_source=coolify.io)
+- [The official website](https://www.bugsink.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/bugsink/bugsink/?utm_source=coolify.io)

--- a/docs/services/changedetection.md
+++ b/docs/services/changedetection.md
@@ -3,7 +3,6 @@ title: "Change Detection"
 description: "Monitor website changes on Coolify with Change Detection featuring automatic tracking, alerts, visual diffs, and API endpoint monitoring."
 ---
 
-
 ![Change Detection](https://raw.githubusercontent.com/dgtlmoon/changedetection.io/master/docs/screenshot.png)
 
 ## What is Change Detection?
@@ -55,5 +54,5 @@ Live your data-life pro-actively.
 
 ## Links
 
-- [The official website ›](https://changedetection.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/dgtlmoon/changedetection.io?utm_source=coolify.io)
+- [The official website](https://changedetection.io?utm_source=coolify.io)
+- [GitHub](https://github.com/dgtlmoon/changedetection.io?utm_source=coolify.io)

--- a/docs/services/chaskiq.md
+++ b/docs/services/chaskiq.md
@@ -3,7 +3,6 @@ title: "Chaskiq"
 description: "Run Chaskiq customer engagement platform on Coolify with live chat, email campaigns, knowledge base, and conversational marketing automation."
 ---
 
-
 ![Chaskiq](https://user-images.githubusercontent.com/11976/81771025-eaefe780-94af-11ea-881b-ad7910536fee.png)
 
 ## What is Chaskiq?
@@ -12,5 +11,5 @@ Chaskiq is an open source chat platform that allows you to chat with your custom
 
 ## Links
 
-- [The official website ›](https://chaskiq.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/chaskiq/chaskiq?utm_source=coolify.io)
+- [The official website](https://chaskiq.io?utm_source=coolify.io)
+- [GitHub](https://github.com/chaskiq/chaskiq?utm_source=coolify.io)

--- a/docs/services/chatwoot.md
+++ b/docs/services/chatwoot.md
@@ -11,5 +11,5 @@ Chatwoot gives you all the tools to manage conversations, build relationships an
 
 ## Links
 
-- [The official website ›](https://www.chatwoot.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/chatwoot/chatwoot?utm_source=coolify.io)
+- [The official website](https://www.chatwoot.com?utm_source=coolify.io)
+- [GitHub](https://github.com/chatwoot/chatwoot?utm_source=coolify.io)

--- a/docs/services/chroma.md
+++ b/docs/services/chroma.md
@@ -13,5 +13,5 @@ Chroma is an open-source, AI-native vector database designed for building applic
 
 ## Links
 
-- [The official website ›](https://www.trychroma.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/chroma-core/chroma?utm_source=coolify.io)
+- [The official website](https://www.trychroma.com?utm_source=coolify.io)
+- [GitHub](https://github.com/chroma-core/chroma?utm_source=coolify.io)

--- a/docs/services/classicpress.md
+++ b/docs/services/classicpress.md
@@ -11,7 +11,7 @@ ClassicPress is a community-led open source content management system for creato
 
 For more information, see:
 
-- [The official website ›](https://www.classicpress.net?utm_source=coolify.io)
-- [The ClassicPress documentation ›](https://docs.classicpress.net?utm_source=coolify.io)
-- [The ClassicPress governance ›](https://www.classicpress.net/governance?utm_source=coolify.io)
-- [Suggest features ›](https://github.com/ClassicPress/ClassicPress/issues?utm_source=coolify.io)
+- [The official website](https://www.classicpress.net?utm_source=coolify.io)
+- [The ClassicPress documentation](https://docs.classicpress.net?utm_source=coolify.io)
+- [The ClassicPress governance](https://www.classicpress.net/governance?utm_source=coolify.io)
+- [Suggest features](https://github.com/ClassicPress/ClassicPress/issues?utm_source=coolify.io)

--- a/docs/services/cloudflared.md
+++ b/docs/services/cloudflared.md
@@ -3,7 +3,6 @@ title: "Cloudflared"
 description: "Run Cloudflare Tunnel on Coolify to expose local services securely without port forwarding using cloudflared for remote access and protection."
 ---
 
-
 ![Cloudflare](https://avatars.githubusercontent.com/u/314135?s=200&v=4)
 
 ## What is Cloudflared?
@@ -12,5 +11,5 @@ Cloudflare Tunnel is tunneling software that lets you quickly secure and encrypt
 
 ## Links
 
-- [The official website ›](https://www.cloudflare.com/products/tunnel?utm_source=coolify.io)
-- [GitHub ›](https://github.com/cloudflare/cloudflared?utm_source=coolify.io)
+- [The official website](https://www.cloudflare.com/products/tunnel?utm_source=coolify.io)
+- [GitHub](https://github.com/cloudflare/cloudflared?utm_source=coolify.io)

--- a/docs/services/code-server.md
+++ b/docs/services/code-server.md
@@ -4,6 +4,7 @@ description: "Run VS Code in browser on Coolify with code-server for remote deve
 ---
 
 # Code Server
+
 ![Code Server1](https://github.com/coder/code-server/raw/main/docs/assets/screenshot-1.png)
 ![Code Server2](https://github.com/coder/code-server/raw/main/docs/assets/screenshot-2.png)
 
@@ -29,5 +30,5 @@ See answers to [frequently asked questions](https://coder.com/docs/code-server/l
 
 ## Links
 
-- [The official website ›](https://coder.com/docs/code-server/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/coder/code-server?utm_source=coolify.io)
+- [The official website](https://coder.com/docs/code-server/?utm_source=coolify.io)
+- [GitHub](https://github.com/coder/code-server?utm_source=coolify.io)

--- a/docs/services/codimd.md
+++ b/docs/services/codimd.md
@@ -5,16 +5,15 @@ description: "Deploy CodiMD collaborative markdown editor on Coolify with real-t
 
 <ZoomableImage src="/docs/images/services/codimd-logo.webp" alt="Codimd Logo logo" />
 
-
 ## What is CodiMD?
+
 CodiMD lets you collaborate in real-time with markdown. Built on HackMD source code, CodiMD lets you host and control your team's content with speed and ease.
 
-
 ## Screenshots
-<ZoomableImage src="/docs/images/services/codimd-screenshots.webp" alt="Codimd interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/codimd-screenshots.webp" alt="Codimd interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation?utm_source=coolify.io)
-- [GitHub ›](https://github.com/hackmdio/codimd?utm_source=coolify.io)
+- [The official website](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation?utm_source=coolify.io)
+- [GitHub](https://github.com/hackmdio/codimd?utm_source=coolify.io)

--- a/docs/services/dashboard.md
+++ b/docs/services/dashboard.md
@@ -3,7 +3,6 @@ title: "Dashboard"
 description: "Deploy customizable dashboard on Coolify for application shortcuts, bookmarks, service monitoring, and centralized access to self-hosted tools."
 ---
 
-
 ![dashboard](https://i.imgur.com/tOnPDYQ.png)
 
 ## What is Dashboard?
@@ -21,4 +20,4 @@ So what makes this project different from (or even better than) SUI?
 
 ## Links
 
-- [GitHub ›](https://github.com/phntxx/dashboard?utm_source=coolify.io)
+- [GitHub](https://github.com/phntxx/dashboard?utm_source=coolify.io)

--- a/docs/services/directus.md
+++ b/docs/services/directus.md
@@ -3,7 +3,6 @@ title: "Directus"
 description: "Deploy Directus headless CMS on Coolify with SQL database wrapper, REST/GraphQL API, no-code data studio, and custom field types for any project."
 ---
 
-
 ![directus](https://user-images.githubusercontent.com/522079/158864859-0fbeae62-9d7a-4619-b35e-f8fa5f68e0c8.png)
 
 ## What is Directus?
@@ -31,5 +30,5 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 
 ## Links
 
-- [The official website ›](https://directus.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/directus/directus?utm_source=coolify.io)
+- [The official website](https://directus.io?utm_source=coolify.io)
+- [GitHub](https://github.com/directus/directus?utm_source=coolify.io)

--- a/docs/services/diun.md
+++ b/docs/services/diun.md
@@ -5,12 +5,11 @@ description: "Monitor Docker images on Coolify with Diun for automatic update no
 
 <ZoomableImage src="/docs/images/services/diun-logo.webp" alt="Diun Logo logo" />
 
-
 ## What is Diun?
-Docker Image Update Notifier is a CLI application written in Go and delivered as a single executable (and a Docker image) to receive notifications when a Docker image is updated on a Docker registry.
 
+Docker Image Update Notifier is a CLI application written in Go and delivered as a single executable (and a Docker image) to receive notifications when a Docker image is updated on a Docker registry.
 
 ## Links
 
-- [The official website ›](https://crazymax.dev/diun/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/crazy-max/diun?utm_source=coolify.io)
+- [The official website](https://crazymax.dev/diun/?utm_source=coolify.io)
+- [GitHub](https://github.com/crazy-max/diun?utm_source=coolify.io)

--- a/docs/services/docker-registry.md
+++ b/docs/services/docker-registry.md
@@ -3,7 +3,6 @@ title: "Docker Registry"
 description: "Host private Docker registry on Coolify for container image storage, distribution, versioning, and secure artifact management for DevOps teams."
 ---
 
-
 ![Docker Registry](https://raw.githubusercontent.com/distribution/distribution/main/distribution-logo.svg)
 
 ## What is Docker Registry?
@@ -12,5 +11,5 @@ Docker Registry is a stateless, highly-available server side application that st
 
 ## Links
 
-- [The official website ›](https://hub.docker.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/docker/distribution?utm_source=coolify.io)
+- [The official website](https://hub.docker.com?utm_source=coolify.io)
+- [GitHub](https://github.com/docker/distribution?utm_source=coolify.io)

--- a/docs/services/docmost.md
+++ b/docs/services/docmost.md
@@ -3,8 +3,8 @@ title: "Docmost"
 description: "Deploy Docmost wiki on Coolify for team documentation, knowledge management, real-time collaboration, and organized information sharing platform."
 ---
 
-
 # What is Docmost?
+
 Docmost is an open-source collaborative wiki and documentation software.
 
 ## Screenshots
@@ -17,5 +17,5 @@ Docmost is an open-source collaborative wiki and documentation software.
 
 ## Links
 
-- [The official website ›](https://www.docmost.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/docmost/docmost?utm_source=coolify.io)
+- [The official website](https://www.docmost.com?utm_source=coolify.io)
+- [GitHub](https://github.com/docmost/docmost?utm_source=coolify.io)

--- a/docs/services/docuseal.md
+++ b/docs/services/docuseal.md
@@ -3,7 +3,6 @@ title: "Docuseal"
 description: "Host DocuSeal on Coolify for PDF form filling, e-signatures, document workflows, and digital signature collection for business process automation."
 ---
 
-
 ## What is Docuseal?
 
 Document Signing for Everyone free forever for individuals, extensible for businesses and developers. Open Source Alternative to DocuSign, PandaDoc and more.
@@ -12,8 +11,7 @@ Document Signing for Everyone free forever for individuals, extensible for busin
 
 <ZoomableImage src="/docs/images/services/docuseal.webp" alt="Docuseal dashboard" />
 
-
 ## Links
 
-- [The official website ›](https://www.docuseal.co?utm_source=coolify.io)
-- [GitHub ›](https://github.com/docusealco/docuseal?utm_source=coolify.io)
+- [The official website](https://www.docuseal.co?utm_source=coolify.io)
+- [GitHub](https://github.com/docusealco/docuseal?utm_source=coolify.io)

--- a/docs/services/dokuwiki.md
+++ b/docs/services/dokuwiki.md
@@ -3,7 +3,6 @@ title: "DokuWiki"
 description: "Deploy DokuWiki on Coolify for flat-file wiki without database, version control, ACL permissions, and plugin extensibility for documentation."
 ---
 
-
 ![DokuWiki](https://www.dokuwiki.org/lib/tpl/dokuwiki/images/logo.png)
 
 ## What is DokuWiki?
@@ -34,5 +33,5 @@ DokuWiki are quick to update and new pages are easily added. Designed for collab
 
 ## Links
 
-- [The official website ›](https://www.dokuwiki.org?utm_source=coolify.io)
-- [GitHub ›](https://github.com/splitbrain/DokuWiki?utm_source=coolify.io)
+- [The official website](https://www.dokuwiki.org?utm_source=coolify.io)
+- [GitHub](https://github.com/splitbrain/DokuWiki?utm_source=coolify.io)

--- a/docs/services/dozzle.md
+++ b/docs/services/dozzle.md
@@ -15,5 +15,5 @@ Dozzle is easy to install and configure, making it an ideal solution for develop
 
 ## Links
 
-- [The official website ›](https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io)
-- [GitHub ›](https://github.com/amir20/dozzle?utm_source=coolify.io)
+- [The official website](https://dozzle.dev/guide/getting-started#running-with-docker?utm_source=coolify.io)
+- [GitHub](https://github.com/amir20/dozzle?utm_source=coolify.io)

--- a/docs/services/drizzle-gateway.md
+++ b/docs/services/drizzle-gateway.md
@@ -13,5 +13,5 @@ Drizzle Studio is a new way for you to explore SQL database on Drizzle ORM proje
 
 ## Links
 
-- [The official website ›](https://orm.drizzle.team/docs/get-started/postgresql-new?utm_source=coolify.io)
-- [GitHub ›](https://github.com/drizzle-team/drizzle-orm?utm_source=coolify.io)
+- [The official website](https://orm.drizzle.team/docs/get-started/postgresql-new?utm_source=coolify.io)
+- [GitHub](https://github.com/drizzle-team/drizzle-orm?utm_source=coolify.io)

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -3,7 +3,6 @@ title: "Duplicati"
 description: "Host Duplicati backup on Coolify with encrypted cloud backups, incremental updates, scheduling, and restore capabilities for data protection."
 ---
 
-
 ![Duplicati](https://avatars.githubusercontent.com/u/8270231?s=200&v=4)
 
 ## What is Duplicati?
@@ -12,5 +11,5 @@ Free backup software to store encrypted backups online for Windows, macOS and Li
 
 ## Links
 
-- [The official website ›](https://www.duplicati.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/duplicati/duplicati?utm_source=coolify.io)
+- [The official website](https://www.duplicati.com?utm_source=coolify.io)
+- [GitHub](https://github.com/duplicati/duplicati?utm_source=coolify.io)

--- a/docs/services/elasticsearch.md
+++ b/docs/services/elasticsearch.md
@@ -61,5 +61,5 @@ If any of the above steps are unclear, you can refer to [this Pull Request](http
 
 ## Useful Links
 
-- [Official Website ›](https://www.elastic.co/?utm_source=coolify.io)
-- [Official Documentation ›](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/install-kibana-with-docker?utm_source=coolify.io)
+- [Official Website](https://www.elastic.co/?utm_source=coolify.io)
+- [Official Documentation](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/install-kibana-with-docker?utm_source=coolify.io)

--- a/docs/services/emby-stat.md
+++ b/docs/services/emby-stat.md
@@ -3,7 +3,6 @@ title: "Emby Stat"
 description: "Track Emby server usage on Coolify with EmbyStat featuring media statistics, playback analytics, user metrics, and library health monitoring."
 ---
 
-
 ![Emby Stat](https://raw.githubusercontent.com/mregni/EmbyStat/develop/branding/logo-color.png)
 
 ## What is Emby Stat?
@@ -12,4 +11,4 @@ EmbyStat is a personal web server that can calculate all kinds of statistics fro
 
 ## Links
 
-- [The official website ›](https://github.com/mregni/EmbyStat?utm_source=coolify.io)
+- [The official website](https://github.com/mregni/EmbyStat?utm_source=coolify.io)

--- a/docs/services/emby.md
+++ b/docs/services/emby.md
@@ -3,7 +3,6 @@ title: "Emby"
 description: "Host Emby media server on Coolify for streaming movies, TV shows, music, and photos with transcoding, mobile apps, and DVR capabilities."
 ---
 
-
 ![Emby](https://emby.media/support/images/logo.png)
 
 ## What is Emby?
@@ -34,5 +33,5 @@ Windows, Mac, Linux, or FreeBSD computer
 
 ## Community
 
-- [The official website ›](https://emby.media?utm_source=coolify.io)
-- [The Emby community ›](https://emby.media/community?utm_source=coolify.io)
+- [The official website](https://emby.media?utm_source=coolify.io)
+- [The Emby community](https://emby.media/community?utm_source=coolify.io)

--- a/docs/services/ente.md
+++ b/docs/services/ente.md
@@ -96,6 +96,6 @@ minio/mc ls myminio
 
 ## Links
 
-- [The official website ›](https://ente.io?utm_source=coolify.io)
-- [Documentation ›](https://help.ente.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/ente-io/ente?utm_source=coolify.io)
+- [The official website](https://ente.io?utm_source=coolify.io)
+- [Documentation](https://help.ente.io?utm_source=coolify.io)
+- [GitHub](https://github.com/ente-io/ente?utm_source=coolify.io)

--- a/docs/services/evolution-api.md
+++ b/docs/services/evolution-api.md
@@ -3,7 +3,6 @@ title: "Evolution API"
 description: "Deploy Evolution API on Coolify for WhatsApp Business integration, message automation, chatbot workflows, and customer communication management."
 ---
 
-
 ## What is Evolution API?
 
 Evolution API is a robust platform devoted to empowering small businesses, entrepreneurs, freelancers, and individuals with limited resources—offering more than just a basic WhatsApp™ messaging solution.
@@ -20,6 +19,5 @@ Once everything is running, you can access your https://url/manager.
 
 ## Links
 
-
-- [GitHub ›](https://github.com/EvolutionAPI/evolution-api?utm_source=coolify.io)
-- [Official Documentation ›](https://doc.evolution-api.com/v1/en/get-started/introduction?utm_source=coolify.io)
+- [GitHub](https://github.com/EvolutionAPI/evolution-api?utm_source=coolify.io)
+- [Official Documentation](https://doc.evolution-api.com/v1/en/get-started/introduction?utm_source=coolify.io)

--- a/docs/services/excalidraw.md
+++ b/docs/services/excalidraw.md
@@ -13,5 +13,5 @@ Excalidraw is a virtual whiteboard for sketching hand-drawn like diagrams. It's 
 
 ## Links
 
-- [The official website ›](https://excalidraw.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/excalidraw/excalidraw?utm_source=coolify.io)
+- [The official website](https://excalidraw.com?utm_source=coolify.io)
+- [GitHub](https://github.com/excalidraw/excalidraw?utm_source=coolify.io)

--- a/docs/services/fider.md
+++ b/docs/services/fider.md
@@ -3,7 +3,6 @@ title: "Fider"
 description: "Deploy Fider feedback platform on Coolify for product ideas, feature voting, roadmap planning, and customer feedback collection for product teams."
 ---
 
-
 ![Fider](https://github.com/getfider/fider/raw/main/etc/homepage.png)
 
 ## What is Fider?
@@ -16,4 +15,4 @@ See the official [Fider + Coolify guide](https://docs.fider.io/hosting-coolify?u
 
 ## Links
 
-- [The official website ›](https://fider.io?utm_source=coolify.io)
+- [The official website](https://fider.io?utm_source=coolify.io)

--- a/docs/services/filebrowser.md
+++ b/docs/services/filebrowser.md
@@ -3,13 +3,11 @@ title: "Filebrowser"
 description: "Run File Browser on Coolify for web-based file management with uploads, sharing, search, and access control for self-hosted cloud storage."
 ---
 
-
 ![Filebrowser](https://raw.githubusercontent.com/filebrowser/logo/master/banner.png)
 
 ## What is Filebrowser?
 
 Filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory. It can be used as a standalone app.
-
 
 ## Setup
 
@@ -30,5 +28,5 @@ Credentials: demo/demo
 
 ## Links
 
-- [The official Filebrowser website ›](https://filebrowser.org?utm_source=coolify.io)
-- [GitHub ›](https://github.com/filebrowser/filebrowser?utm_source=coolify.io)
+- [The official Filebrowser website](https://filebrowser.org?utm_source=coolify.io)
+- [GitHub](https://github.com/filebrowser/filebrowser?utm_source=coolify.io)

--- a/docs/services/fileflows.md
+++ b/docs/services/fileflows.md
@@ -27,5 +27,5 @@ FileFlows lets you monitor and process any file type with custom flows. Videos, 
 
 ## Links
 
-- [The official website ›](https://fileflows.com/)
-- [Doc ›](https://fileflows.com/docs)
+- [The official website](https://fileflows.com/)
+- [Doc](https://fileflows.com/docs)

--- a/docs/services/firefly-iii.md
+++ b/docs/services/firefly-iii.md
@@ -3,7 +3,6 @@ title: "Firefly III"
 description: "Manage personal finances on Coolify with Firefly III featuring budgets, reports, recurring transactions, and multi-currency expense tracking."
 ---
 
-
 ![Firefly III](https://raw.githubusercontent.com/firefly-iii/firefly-iii/develop/.github/assets/img/logo-small.png)
 
 ## What is Firefly III?
@@ -20,5 +19,5 @@ But you get the idea: this is your money. These are your expenses. Stop them fro
 
 ## Links
 
-- [The official website ›](https://firefly-iii.org?utm_source=coolify.io)
-- [GitHub ›](https://github.com/firefly-iii/firefly-iii?utm_source=coolify.io)
+- [The official website](https://firefly-iii.org?utm_source=coolify.io)
+- [GitHub](https://github.com/firefly-iii/firefly-iii?utm_source=coolify.io)

--- a/docs/services/forgejo.md
+++ b/docs/services/forgejo.md
@@ -24,9 +24,9 @@ Forejo is also compatible with third-party CI apps and platforms. Forgejo is a G
 
 ## Demo
 
-- [Demo ›](https://next.forgejo.org/)
+- [Demo](https://next.forgejo.org/)
 
 ## Links
 
-- [The official website ›](https://forgejo.org/)
-- [Codeberg ›](https://codeberg.org/forgejo/forgejo)
+- [The official website](https://forgejo.org/)
+- [Codeberg](https://codeberg.org/forgejo/forgejo)

--- a/docs/services/formbricks.md
+++ b/docs/services/formbricks.md
@@ -15,5 +15,5 @@ Formbricks provides a free and open source surveying platform. Gather feedback a
 
 ## Links
 
-- [The official website ›](https://formbricks.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/formbricks/formbricks?utm_source=coolify.io)
+- [The official website](https://formbricks.com?utm_source=coolify.io)
+- [GitHub](https://github.com/formbricks/formbricks?utm_source=coolify.io)

--- a/docs/services/ghost.md
+++ b/docs/services/ghost.md
@@ -11,5 +11,5 @@ Ghost is a powerful app for professional publishers to create, share, and grow a
 
 ## Links
 
-- [The official website ›](https://ghost.org/)
-- [GitHub ›](https://github.com/TryGhost/Ghost)
+- [The official website](https://ghost.org/)
+- [GitHub](https://github.com/TryGhost/Ghost)

--- a/docs/services/gitea.md
+++ b/docs/services/gitea.md
@@ -3,7 +3,6 @@ title: "Gitea"
 description: "Host Gitea Git service on Coolify for lightweight repository hosting with pull requests, CI/CD integration, issues, and team collaboration."
 ---
 
-
 ![Gitea](https://about.gitea.com/gitea-text.svg)
 
 ## What is Gitea?
@@ -12,9 +11,9 @@ Git with a cup of tea! Painless self-hosted all-in-one software development serv
 
 ## Demo
 
-- [Demo ›](https://try.gitea.io/)
+- [Demo](https://try.gitea.io/)
 
 ## Links
 
-- [The official website ›](https://gitea.com)
-- [GitHub ›](https://github.com/go-gitea/gitea)
+- [The official website](https://gitea.com)
+- [GitHub](https://github.com/go-gitea/gitea)

--- a/docs/services/github-runner.md
+++ b/docs/services/github-runner.md
@@ -13,5 +13,5 @@ GitHub Runner is a self-hosted runner for GitHub Actions that allows you to run 
 
 ## Links
 
-- [The official GitHub Actions documentation ›](https://docs.github.com/en/actions/hosting-your-own-runners?utm_source=coolify.io)
-- [GitHub ›](https://github.com/myoung34/docker-github-actions-runner?utm_source=coolify.io)
+- [The official GitHub Actions documentation](https://docs.github.com/en/actions/hosting-your-own-runners?utm_source=coolify.io)
+- [GitHub](https://github.com/myoung34/docker-github-actions-runner?utm_source=coolify.io)

--- a/docs/services/gitlab.md
+++ b/docs/services/gitlab.md
@@ -3,7 +3,6 @@ title: "GitLab"
 description: "Deploy GitLab on Coolify for complete DevOps platform with Git repos, CI/CD pipelines, issue tracking, and container registry integration."
 ---
 
-
 ![Gitlab](https://raw.githubusercontent.com/gitlabhq/gitlabhq/refs/heads/master/public/apple-touch-icon.png)
 
 ## What is GitLab?
@@ -12,9 +11,9 @@ GitLab is a web-based DevOps lifecycle tool that provides a Git-repository manag
 
 ## Demo
 
-- [Demo ›](https://gitlab.com/)
+- [Demo](https://gitlab.com/)
 
 ## Links
 
-- [The official website ›](https://about.gitlab.com)
-- [GitLab ›](https://gitlab.com/gitlab-org/gitlab)
+- [The official website](https://about.gitlab.com)
+- [GitLab](https://gitlab.com/gitlab-org/gitlab)

--- a/docs/services/glance.md
+++ b/docs/services/glance.md
@@ -4,6 +4,7 @@ description: "Host Glance dashboard on Coolify for quick server overview, system
 ---
 
 # Glance
+
 A self-hosted dashboard that puts all your feeds in one place.
 
 ## Screenshots
@@ -12,4 +13,4 @@ A self-hosted dashboard that puts all your feeds in one place.
 
 ## Links
 
-- [The official website ›](https://github.com/glanceapp/glance)
+- [The official website](https://github.com/glanceapp/glance)

--- a/docs/services/glances.md
+++ b/docs/services/glances.md
@@ -3,7 +3,6 @@ title: "Glances"
 description: "Monitor system performance on Coolify with Glances showing CPU, memory, disk, network stats, and process monitoring via web interface."
 ---
 
-
 ![Glances](https://raw.githubusercontent.com/nicolargo/glances/develop/docs/_static/glances-responsive-webdesign.png)
 
 ## What is Glances?
@@ -12,5 +11,5 @@ Glances is a cross-platform monitoring tool which aims to provide a simple yet e
 
 ## Links
 
-- [The official website ›](https://nicolargo.github.io/glances/)
-- [GitHub ›](https://github.com/nicolargo/glances)
+- [The official website](https://nicolargo.github.io/glances/)
+- [GitHub](https://github.com/nicolargo/glances)

--- a/docs/services/glitchtip.md
+++ b/docs/services/glitchtip.md
@@ -3,7 +3,6 @@ title: "Glitchtip"
 description: "Deploy GlitchTip error tracking on Coolify as open-source Sentry alternative for exception monitoring, performance tracking, and debugging."
 ---
 
-
 ![Glitchtip](https://glitchtip.com/assets/logo-again.svg)
 
 ## What is Glitchtip?
@@ -12,5 +11,5 @@ Track errors, uptime, and performance. An open source reimplementation of Sentry
 
 ## Links
 
-- [The official website ›](https://glitchtip.com/)
-- [GitHub ›](https://gitlab.com/glitchtip)
+- [The official website](https://glitchtip.com/)
+- [GitHub](https://gitlab.com/glitchtip)

--- a/docs/services/gotenberg.md
+++ b/docs/services/gotenberg.md
@@ -3,7 +3,6 @@ title: "Gotenberg"
 description: "Run Gotenberg on Coolify for PDF generation from HTML, Markdown, Office files via Docker-based microservice with REST API for conversions."
 ---
 
-
 ![Gotenberg](https://user-images.githubusercontent.com/8983173/130322857-185831e2-f041-46eb-a17f-0a69d066c4e5.png)
 
 ## What is Gotenberg?
@@ -15,5 +14,5 @@ Gotenberg **has no UI**. Head to the [documentation](https://gotenberg.dev/docs/
 
 ## Links
 
-- [Official Website ›](https://gotenberg.dev)
-- [GitHub ›](https://github.com/gotenberg/gotenberg)
+- [Official Website](https://gotenberg.dev)
+- [GitHub](https://github.com/gotenberg/gotenberg)

--- a/docs/services/gotify.md
+++ b/docs/services/gotify.md
@@ -38,8 +38,8 @@ Perfect for receiving notifications from:
 
 ## Links
 
-- [The official website ›](https://gotify.net/)
-- [GitHub ›](https://github.com/gotify/server)
-- [Documentation ›](https://gotify.net/docs/)
-- [Android App (Google Play) ›](https://play.google.com/store/apps/details?id=com.github.gotify)
-- [Android App (F-Droid) ›](https://f-droid.org/de/packages/com.github.gotify/)
+- [The official website](https://gotify.net/)
+- [GitHub](https://github.com/gotify/server)
+- [Documentation](https://gotify.net/docs/)
+- [Android App (Google Play)](https://play.google.com/store/apps/details?id=com.github.gotify)
+- [Android App (F-Droid)](https://f-droid.org/de/packages/com.github.gotify/)

--- a/docs/services/gowa.md
+++ b/docs/services/gowa.md
@@ -13,4 +13,4 @@ GoWa (Golang WhatsApp) is a WhatsApp Web API service built with Go for efficient
 
 ## Links
 
-- [GitHub ›](https://github.com/aldinokemal/go-whatsapp-web-multidevice?utm_source=coolify.io)
+- [GitHub](https://github.com/aldinokemal/go-whatsapp-web-multidevice?utm_source=coolify.io)

--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -3,7 +3,6 @@ title: "Grafana"
 description: "Deploy Grafana on Coolify for data visualization, monitoring dashboards, alerting, and metric analysis from multiple data sources and databases."
 ---
 
-
 ![Grafana](https://github.com/grafana/grafana/raw/main/docs/logo-horizontal.png#gh-light-mode-only)
 
 ## What is Grafana?
@@ -23,5 +22,5 @@ Grafana allows you to query, visualize, alert on and understand your metrics no 
 
 ## Links
 
-- [The official website ›](https://grafana.com/)
-- [GitHub ›](https://github.com/grafana/grafana)
+- [The official website](https://grafana.com/)
+- [GitHub](https://github.com/grafana/grafana)

--- a/docs/services/gramps-web.md
+++ b/docs/services/gramps-web.md
@@ -19,5 +19,5 @@ or as a companion to Gramps Desktop, with full control over your data and privac
 
 ## Links
 
-- [Official website ↗](https://www.grampsweb.org/?utm_source=coolify.io)
-- [GitHub ↗](https://github.com/gramps-project/gramps-web?utm_source=coolify.io)
+- [Official website](https://www.grampsweb.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/gramps-project/gramps-web?utm_source=coolify.io)

--- a/docs/services/grist.md
+++ b/docs/services/grist.md
@@ -5,11 +5,11 @@ description: "Run Grist spreadsheet on Coolify combining spreadsheets and databa
 
 <ZoomableImage src="/docs/images/services/grist-logo.webp" alt="Grist Logo logo" />
 
-
 ## What is Grist?
+
 Grist is a modern relational spreadsheet. It combines the flexibility of a spreadsheet with the robustness of a database.
 
 ## Links
 
-- [The official website ›](https://getgrist.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/gristlabs/grist-core?utm_source=coolify.io)
+- [The official website](https://getgrist.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/gristlabs/grist-core?utm_source=coolify.io)

--- a/docs/services/grocy.md
+++ b/docs/services/grocy.md
@@ -3,7 +3,6 @@ title: "Grocy"
 description: "Manage household on Coolify with Grocy for grocery inventory, recipe management, chore tracking, and smart shopping lists for home organization."
 ---
 
-
 ![Grocy](https://raw.githubusercontent.com/grocy/grocy/master/public/img/logo.svg?sanitize=true)
 
 ## What is Grocy?
@@ -12,5 +11,5 @@ Grocy is a web-based self-hosted groceries & household management solution for y
 
 ## Links
 
-- [The official website ›](https://grocy.info)
-- [GitHub ›](https://github.com/grocy/grocy)
+- [The official website](https://grocy.info)
+- [GitHub](https://github.com/grocy/grocy)

--- a/docs/services/heimdall.md
+++ b/docs/services/heimdall.md
@@ -3,7 +3,6 @@ title: "Heimdall"
 description: "Deploy Heimdall dashboard on Coolify for application launcher, bookmark manager, and organized access point to all your self-hosted services."
 ---
 
-
 ![Heimdall](https://camo.githubusercontent.com/0b7b7b9940d2234a4edc1af41c191c62b716baf21a0803a38b0cc9d5328db54e/68747470733a2f2f692e696d6775722e636f6d2f697556387733792e706e67)
 
 ## What is Heimdall?
@@ -20,5 +19,5 @@ Why not use it as your browser start page? It even has the ability to include a 
 
 ## Links
 
-- [The official website ›](https://heimdall.site/)
-- [GitHub ›](https://github.com/linuxserver/Heimdall)
+- [The official website](https://heimdall.site/)
+- [GitHub](https://github.com/linuxserver/Heimdall)

--- a/docs/services/homebox.md
+++ b/docs/services/homebox.md
@@ -13,4 +13,4 @@ Homebox is an inventory and organization system built specifically for home user
 
 ## Links
 
-- [GitHub ›](https://github.com/hay-kot/homebox?utm_source=coolify.io)
+- [GitHub](https://github.com/hay-kot/homebox?utm_source=coolify.io)

--- a/docs/services/homepage.md
+++ b/docs/services/homepage.md
@@ -15,4 +15,4 @@ A modern, fully static, fast, secure fully proxied, highly customizable applicat
 
 ## Links
 
-- [The official website ›](https://gethomepage.dev/latest/)
+- [The official website](https://gethomepage.dev/latest/)

--- a/docs/services/infisical.md
+++ b/docs/services/infisical.md
@@ -20,5 +20,5 @@ Infisical is the open source security infrastructure platform that engineers use
 
 ## Links
 
-- [The official website ›](https://infisical.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/Infisical/infisical?utm_source=coolify.io)
+- [The official website](https://infisical.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/Infisical/infisical?utm_source=coolify.io)

--- a/docs/services/invoice-ninja.md
+++ b/docs/services/invoice-ninja.md
@@ -13,4 +13,4 @@ A self-hosted invoicing platform for small businesses.
 
 ## Links
 
-- [The official website ›](https://www.invoiceninja.com/)
+- [The official website](https://www.invoiceninja.com/)

--- a/docs/services/jellyfin.md
+++ b/docs/services/jellyfin.md
@@ -3,16 +3,15 @@ title: "Jellyfin"
 description: "Deploy Jellyfin media server on Coolify for streaming movies, TV shows, music with no licensing, transcoding, and mobile app support."
 ---
 
-
 ![Jellyfin](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true)
 
 ## What is Jellyfin?
 
-Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. 
+Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support.
 
 There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!
 
 ## Links
 
-- [The official website ›](https://jellyfin.org/)
-- [GitHub ›](https://github.com/jellyfin/jellyfin)
+- [The official website](https://jellyfin.org/)
+- [GitHub](https://github.com/jellyfin/jellyfin)

--- a/docs/services/jenkins.md
+++ b/docs/services/jenkins.md
@@ -3,7 +3,6 @@ title: "Jenkins"
 description: "Run Jenkins CI/CD on Coolify for automated builds, testing, deployment pipelines, and continuous integration workflows with extensive plugins."
 ---
 
-
 ![Jenkins](https://www.jenkins.io/images/jenkins-logo-title-dark.svg)
 
 ## What is Jenkins?
@@ -12,5 +11,5 @@ Jenkins is a popular open-source automation server used for continuous integrati
 
 ## Links
 
-- [The official website ›](https://www.jenkins.io/)
-- [GitHub ›](https://github.com/jenkinsci/jenkins)
+- [The official website](https://www.jenkins.io/)
+- [GitHub](https://github.com/jenkinsci/jenkins)

--- a/docs/services/karakeep.md
+++ b/docs/services/karakeep.md
@@ -13,5 +13,5 @@ KaraKeep is a self-hostable bookmark-everything app with AI-based automatic tagg
 
 ## Links
 
-- [The official website ›](https://docs.karakeep.app?utm_source=coolify.io)
-- [GitHub ›](https://github.com/karakeep-app/karakeep?utm_source=coolify.io)
+- [The official website](https://docs.karakeep.app?utm_source=coolify.io)
+- [GitHub](https://github.com/karakeep-app/karakeep?utm_source=coolify.io)

--- a/docs/services/kimai.md
+++ b/docs/services/kimai.md
@@ -3,7 +3,6 @@ title: "Kimai"
 description: "Track time on Coolify with Kimai for project time tracking, invoicing, reporting, and team productivity management with mobile support."
 ---
 
-
 ![Kimai](https://raw.githubusercontent.com/kimai/www.kimai.org/refs/heads/main/images/kimai_logo.webp)
 
 ## What is Kimai?
@@ -14,10 +13,9 @@ Kimai makes time-tracking easy. An open-source solution for teams of all sizes.
 
 ![Configurable Kimai Dashboard](https://raw.githubusercontent.com/kimai/www.kimai.org/refs/heads/main/images/screenshots/screenshot-dashboard.webp)
 
-
 ![Project detail-report screen](https://raw.githubusercontent.com/kimai/www.kimai.org/refs/heads/main/images/screenshots/screenshot-reporting.webp)
 
 ## Links
 
-- [The official website ›](https://www.kimai.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/kimai/kimai)
+- [The official website](https://www.kimai.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/kimai/kimai)

--- a/docs/services/kuzzle.md
+++ b/docs/services/kuzzle.md
@@ -3,7 +3,6 @@ title: "Kuzzle"
 description: "Run Kuzzle backend on Coolify for real-time APIs, authentication, data storage, geofencing, and IoT platform with pub/sub messaging."
 ---
 
-
 ![Kuzzle](https://user-images.githubusercontent.com/7868838/103797784-32337580-5049-11eb-8917-3fcf4487644c.png)
 
 ## What is Kuzzle?
@@ -25,5 +24,5 @@ Kuzzle enables you to build modern web applications and complex IoT networks in 
 
 ## Links
 
-- [The official website ›](https://kuzzle.io/)
-- [GitHub ›](https://github.com/kuzzleio/kuzzle)
+- [The official website](https://kuzzle.io/)
+- [GitHub](https://github.com/kuzzleio/kuzzle)

--- a/docs/services/labelstudio.md
+++ b/docs/services/labelstudio.md
@@ -17,4 +17,4 @@ Label Studio is an open-source data labeling platform that streamlines the proce
 
 ## Links
 
-- [The official website ›](https://labelstud.io/)
+- [The official website](https://labelstud.io/)

--- a/docs/services/leantime.md
+++ b/docs/services/leantime.md
@@ -5,16 +5,15 @@ description: "Manage projects on Coolify with Leantime featuring tasks, gantt ch
 
 <ZoomableImage src="/docs/images/services/leantime-logo.webp" alt="Leantime Logo logo" />
 
-
 ## What is Leantime?
+
 Leantime is a goals focused project management system for non-project managers. Building with ADHD, Autism, and dyslexia in mind.
 
-
 ## Screenshots
-<ZoomableImage src="/docs/images/services/leantime-screenshots.webp" alt="Leantime interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/leantime-screenshots.webp" alt="Leantime interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://leantime.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/leantime/leantime?utm_source=coolify.io)
+- [The official website](https://leantime.io?utm_source=coolify.io)
+- [GitHub](https://github.com/leantime/leantime?utm_source=coolify.io)

--- a/docs/services/librechat.md
+++ b/docs/services/librechat.md
@@ -13,5 +13,5 @@ LibreChat is a self-hosted, powerful, and privacy-focused chat UI for multiple A
 
 ## Links
 
-- [The official website ›](https://librechat.ai?utm_source=coolify.io)
-- [GitHub ›](https://github.com/danny-avila/LibreChat?utm_source=coolify.io)
+- [The official website](https://librechat.ai?utm_source=coolify.io)
+- [GitHub](https://github.com/danny-avila/LibreChat?utm_source=coolify.io)

--- a/docs/services/limesurvey.md
+++ b/docs/services/limesurvey.md
@@ -5,15 +5,13 @@ description: "Create surveys on Coolify with LimeSurvey featuring questionnaire 
 
 <ZoomableImage src="/docs/images/services/limesurvey.webp" alt="Limesurvey Logo logo" />
 
-
 ## What is LimeSurvey?
-A powerful, open-source survey platform. 
+
+A powerful, open-source survey platform.
 
 A free alternative to SurveyMonkey, Typeform, Qualtrics, and Google Forms, making it simple to create online surveys and forms with unmatched flexibility.
 
-
-
 ## Links
 
-- [The official website ›](https://www.limesurvey.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/LimeSurvey/LimeSurvey?utm_source=coolify.io)
+- [The official website](https://www.limesurvey.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/LimeSurvey/LimeSurvey?utm_source=coolify.io)

--- a/docs/services/listmonk.md
+++ b/docs/services/listmonk.md
@@ -3,7 +3,6 @@ title: "Listmonk"
 description: "Run Listmonk newsletter on Coolify for email campaigns, subscriber management, templates, analytics, and high-performance mailing lists."
 ---
 
-
 ![Listmonk](https://user-images.githubusercontent.com/547147/231084896-835dba66-2dfe-497c-ba0f-787564c0819e.png)
 
 ## What is Listmonk?
@@ -16,5 +15,5 @@ Self-hosted newsletter and mailing list manager.
 
 ## Links
 
-- [The official website ›](https://listmonk.app/)
-- [GitHub ›](https://github.com/knadh/listmonk)
+- [The official website](https://listmonk.app/)
+- [GitHub](https://github.com/knadh/listmonk)

--- a/docs/services/litellm.md
+++ b/docs/services/litellm.md
@@ -20,4 +20,4 @@ LiteLLM is an open-source LLM Gateway to manage authentication, loadbalancing, a
 
 ## Links
 
-- [The official website ›](https://docs.litellm.ai?utm_source=coolify.io)
+- [The official website](https://docs.litellm.ai?utm_source=coolify.io)

--- a/docs/services/logto.md
+++ b/docs/services/logto.md
@@ -32,5 +32,5 @@ In a more approachable way, we refer to this solution as "[Customer Identity Acc
 
 ## Links
 
-- [The official website ›](https://logto.io)
-- [GitHub ›](https://github.com/logto-io/logto)
+- [The official website](https://logto.io)
+- [GitHub](https://github.com/logto-io/logto)

--- a/docs/services/mailpit.md
+++ b/docs/services/mailpit.md
@@ -13,5 +13,5 @@ Mailpit is a self-hosted email and SMTP testing tool with a web interface.
 
 ## Links
 
-- [The official website ›](https://mailpit.axllent.org)
-- [GitHub ›](https://github.com/axllent/mailpit)
+- [The official website](https://mailpit.axllent.org)
+- [GitHub](https://github.com/axllent/mailpit)

--- a/docs/services/marimo.md
+++ b/docs/services/marimo.md
@@ -5,11 +5,11 @@ description: "Deploy Marimo reactive notebooks on Coolify for Python data scienc
 
 <ZoomableImage src="/docs/images/services/marimo-logo.webp" alt="Marimo Logo logo" />
 
-
 ## What is Marimo?
+
 Marimo is an open-source reactive notebook for Python — reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.
 
 ## Links
 
-- [The official website ›](https://marimo.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/marimo-team/marimo?utm_source=coolify.io)
+- [The official website](https://marimo.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/marimo-team/marimo?utm_source=coolify.io)

--- a/docs/services/matrix.md
+++ b/docs/services/matrix.md
@@ -13,5 +13,5 @@ Matrix is an open-source, decentralized communication protocol that enables secu
 
 ## Links
 
-- [The official website ›](https://matrix.org?utm_source=coolify.io)
-- [GitHub ›](https://github.com/matrix-org/synapse?utm_source=coolify.io)
+- [The official website](https://matrix.org?utm_source=coolify.io)
+- [GitHub](https://github.com/matrix-org/synapse?utm_source=coolify.io)

--- a/docs/services/mediawiki.md
+++ b/docs/services/mediawiki.md
@@ -23,5 +23,5 @@ Free and open source collaborative space for managing and sharing knowledge.
 
 ## Links
 
-- [The official website ›](https://www.mediawiki.org/wiki/MediaWiki)
-- [GitHub ›](https://github.com/wikimedia/mediawiki)
+- [The official website](https://www.mediawiki.org/wiki/MediaWiki)
+- [GitHub](https://github.com/wikimedia/mediawiki)

--- a/docs/services/meilisearch.md
+++ b/docs/services/meilisearch.md
@@ -32,5 +32,5 @@ Meilisearch helps you shape a delightful search experience in a snap, offering f
 
 ## Links
 
-- [The official website ›](https://www.meilisearch.com)
-- [GitHub ›](https://github.com/meilisearch/meilisearch)
+- [The official website](https://www.meilisearch.com)
+- [GitHub](https://github.com/meilisearch/meilisearch)

--- a/docs/services/memos.md
+++ b/docs/services/memos.md
@@ -5,14 +5,15 @@ description: "Host Memos note-taking on Coolify for quick thoughts, lightweight 
 
 <ZoomableImage src="/docs/images/services/memos.webp" alt="Memos Logo logo" />
 
-
 ## What is Memos?
+
 An open-source, lightweight note-taking solution. The pain-less way to create your meaningful notes. Your Notes, Your Way.
 
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/memos-screenshots.webp" alt="Memos interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://usememos.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/usememos/memos?utm_source=coolify.io)
+- [The official website](https://usememos.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/usememos/memos?utm_source=coolify.io)

--- a/docs/services/metabase.md
+++ b/docs/services/metabase.md
@@ -23,6 +23,5 @@ Metabase is the easy, open-source way for everyone in your company to ask questi
 
 ## Links
 
-- [The official website ›](https://www.metabase.com/)
-- [Github ›](https://github.com/metabase/metabase)
-
+- [The official website](https://www.metabase.com/)
+- [Github](https://github.com/metabase/metabase)

--- a/docs/services/metube.md
+++ b/docs/services/metube.md
@@ -11,4 +11,4 @@ Web GUI for youtube-dl (using the yt-dlp fork) with playlist support. Allows you
 
 ## Links
 
-- [GitHub ›](https://github.com/alexta69/metube)
+- [GitHub](https://github.com/alexta69/metube)

--- a/docs/services/minecraft.md
+++ b/docs/services/minecraft.md
@@ -3,13 +3,12 @@ title: "Minecraft"
 description: "Run Minecraft server on Coolify for multiplayer gaming, custom worlds, mods support, and community gameplay with dedicated server hosting."
 ---
 
-
 # What is Minecraft?
 
-Minecraft is a sandbox video game developed by Mojang Studios. The game was created by Markus "Notch" Persson in the Java programming language. 
+Minecraft is a sandbox video game developed by Mojang Studios. The game was created by Markus "Notch" Persson in the Java programming language.
 
 It is a single-player and multiplayer game that allows players to explore, build, and mine in a procedurally generated world.
 
 ## Links
 
-- [GitHub ›](https://github.com/itzg/docker-minecraft-server)
+- [GitHub](https://github.com/itzg/docker-minecraft-server)

--- a/docs/services/miniflux.md
+++ b/docs/services/miniflux.md
@@ -13,5 +13,5 @@ Miniflux is a minimalist and opinionated feed reader that focuses on simplicity 
 
 ## Links
 
-- [The official website ›](https://miniflux.app?utm_source=coolify.io)
-- [GitHub ›](https://github.com/miniflux/v2?utm_source=coolify.io)
+- [The official website](https://miniflux.app?utm_source=coolify.io)
+- [GitHub](https://github.com/miniflux/v2?utm_source=coolify.io)

--- a/docs/services/minio.md
+++ b/docs/services/minio.md
@@ -3,7 +3,6 @@ title: "MinIO"
 description: "Host MinIO object storage on Coolify as S3-compatible high-performance storage for backups, data lakes, and cloud-native application storage."
 ---
 
-
 ![MinIO](https://github.com/minio.png)
 
 ## What is MinIO?
@@ -12,7 +11,7 @@ MinIO is a high-performance, distributed object storage system. It is software-d
 
 ## Links
 
-- [The official website ›](https://min.io/)
+- [The official website](https://min.io/)
 
 ## FAQ
 

--- a/docs/services/mixpost.md
+++ b/docs/services/mixpost.md
@@ -3,7 +3,6 @@ title: "Mixpost"
 description: "Run Mixpost social media on Coolify for scheduling, analytics, content calendar, and multi-platform social media management self-hosted solution."
 ---
 
-
 ![Mixpost](https://raw.githubusercontent.com/inovector/mixpost/main/art/logo.svg)
 
 ## What is Mixpost?
@@ -12,5 +11,5 @@ Self-hosted social media management software (Buffer alternative).
 
 ## Links
 
-- [The official Mixpost website ›](https://mixpost.app/)
-- [GitHub ›](https://github.com/inovector/mixpost)
+- [The official Mixpost website](https://mixpost.app/)
+- [GitHub](https://github.com/inovector/mixpost)

--- a/docs/services/moodle.md
+++ b/docs/services/moodle.md
@@ -3,7 +3,6 @@ title: "Moodle"
 description: "Deploy Moodle LMS on Coolify for online learning, course management, assignments, quizzes, and educational platform with extensive plugins."
 ---
 
-
 ![Moodle](https://raw.githubusercontent.com/moodle/moodle/main/.github/moodlelogo.svg)
 
 ## What is Moodle?
@@ -12,5 +11,5 @@ Moodle is an open-source learning platform that provides a secure and private al
 
 ## Links
 
-- [The official website ›](https://moodle.com/)
-- [GitHub ›](https://github.com/moodle/moodle)
+- [The official website](https://moodle.com/)
+- [GitHub](https://github.com/moodle/moodle)

--- a/docs/services/mosquitto.md
+++ b/docs/services/mosquitto.md
@@ -11,5 +11,5 @@ Mosquitto is an open-source MQTT (Message Queuing Telemetry Transport) broker th
 
 ## Links
 
-- [The official website ›](https://mosquitto.org/)
-- [GitHub ›](https://github.com/eclipse/mosquitto)
+- [The official website](https://mosquitto.org/)
+- [GitHub](https://github.com/eclipse/mosquitto)

--- a/docs/services/n8n.md
+++ b/docs/services/n8n.md
@@ -3,7 +3,6 @@ title: "N8N"
 description: "Build workflows on Coolify with n8n automation platform connecting 400+ apps, APIs, databases for no-code/low-code task automation and integration."
 ---
 
-
 ![N8N](https://user-images.githubusercontent.com/65276001/173571060-9f2f6d7b-bac0-43b6-bdb2-001da9694058.png)
 
 ## What is N8N?
@@ -53,5 +52,5 @@ USER node
 
 ## Links
 
-- [The official website ›](https://n8n.io/)
-- [GitHub ›](https://github.com/n8n-io/n8n)
+- [The official website](https://n8n.io/)
+- [GitHub](https://github.com/n8n-io/n8n)

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -5,15 +5,15 @@ description: "Stream music on Coolify with Navidrome personal server supporting 
 
 <ZoomableImage src="/docs/images/services/navidrome.webp" alt="Navidrome Logo logo" />
 
-
 ## What is Navidrome?
+
 Navidrome is an open source web-based music collection server and streamer. It gives you freedom to listen to your music collection from any browser or mobile device.
 
 ## Screenshots
-<ZoomableImage src="/docs/images/services/navidrome-screenshots.webp" alt="Navidrome interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/navidrome-screenshots.webp" alt="Navidrome interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://www.navidrome.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/navidrome/navidrome/?utm_source=coolify.io)
+- [The official website](https://www.navidrome.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/navidrome/navidrome/?utm_source=coolify.io)

--- a/docs/services/netbird-client.md
+++ b/docs/services/netbird-client.md
@@ -5,12 +5,11 @@ description: "Run NetBird client on Coolify for WireGuard-based mesh VPN, zero-t
 
 <ZoomableImage src="/docs/images/services/netbird-client.webp" alt="Netbird Client Logo logo" />
 
-
 ## What is Netbird-Client?
-Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.
 
+Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.
 
 ## Links
 
-- [The official website ›](https://netbird.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/netbirdio/netbird?utm_source=coolify.io)
+- [The official website](https://netbird.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/netbirdio/netbird?utm_source=coolify.io)

--- a/docs/services/newapi.md
+++ b/docs/services/newapi.md
@@ -13,5 +13,5 @@ The next-generation LLM gateway and AI asset management system supports multiple
 
 ## Links
 
-- [Official website ↗](https://docs.newapi.pro/en/getting-started?utm_source=coolify.io)
-- [GitHub ↗](https://github.com/QuantumNous/new-api?utm_source=coolify.io)
+- [Official website](https://docs.newapi.pro/en/getting-started?utm_source=coolify.io)
+- [GitHub](https://github.com/QuantumNous/new-api?utm_source=coolify.io)

--- a/docs/services/nextcloud.md
+++ b/docs/services/nextcloud.md
@@ -15,5 +15,5 @@ NextCloud is an open-source productivity platform that provides a secure and pri
 
 ## Links
 
-- [The official website ›](https://nextcloud.com/)
-- [GitHub ›](https://github.com/nextcloud/server)
+- [The official website](https://nextcloud.com/)
+- [GitHub](https://github.com/nextcloud/server)

--- a/docs/services/nexus.md
+++ b/docs/services/nexus.md
@@ -5,7 +5,6 @@ description: "Run Nexus Repository on Coolify for artifact management, Docker re
 
 <ZoomableImage src="/docs/images/services/nexus0.webp" alt="Nexus dashboard" />
 
-
 ## What is Sonatype Nexus
 
 Sonatype Nexus is a repository manager that allows you to store, manage, and distribute your software artifacts.
@@ -18,6 +17,7 @@ The official container is for x86_64 architecture. The arm64 version is communit
 - After that, delete `NEXUS_SECURITY_RANDOMPASSWORD=false` line from the compose file and restart the service to apply the changes.
 
 Minimum requirements:
+
 - 4 vCPU
 - 3 GB RAM
 
@@ -28,5 +28,5 @@ Minimum requirements:
 
 ## Links
 
-- [The official website ›](https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io)
-- [GitHub ›](https://github.com/sonatype/docker-nexus3?utm_source=coolify.io)
+- [The official website](https://help.sonatype.com/en/sonatype-nexus-repository.html?utm_source=coolify.io)
+- [GitHub](https://github.com/sonatype/docker-nexus3?utm_source=coolify.io)

--- a/docs/services/nitropage.md
+++ b/docs/services/nitropage.md
@@ -5,12 +5,12 @@ description: "Host NitroPage website builder on Coolify for drag-and-drop page c
 
 <ZoomableImage src="/docs/images/services/nitropage-logo.svg" alt="Nitropage dashboard" />
 
-
 ## What is Nitropage?
+
 Nitropage is an extensible, visual website builder based on SolidStart, offering a growing library of versatile building blocks.
 
-
 ## Features
+
 - Reusable element **Presets** and **Layouts**
 - Publishing workflow with **Revisions**
 - Starter kit with dozens of Blueprints
@@ -20,8 +20,8 @@ Nitropage is an extensible, visual website builder based on SolidStart, offering
 - Powerful developer architecture with [Vite](https://vitejs.dev/?utm_source=coolify.io)
 - Automatic sitemap.xml and Atom-feed handling
 
-
 ## Video
+
 <iframe
   width="560"
   height="315"
@@ -32,7 +32,7 @@ Nitropage is an extensible, visual website builder based on SolidStart, offering
   allowfullscreen
 ></iframe>
 
-
 ## Links
-- [The official website ›](https://nitropage.org/?utm_source=coolify.io)
-- [GitHub ›](https://codeberg.org/nitropage/nitropage?utm_source=coolify.io)
+
+- [The official website](https://nitropage.org/?utm_source=coolify.io)
+- [GitHub](https://codeberg.org/nitropage/nitropage?utm_source=coolify.io)

--- a/docs/services/nocodb.md
+++ b/docs/services/nocodb.md
@@ -18,5 +18,5 @@ NocoDB is an open source Airtable alternative. Turns any MySQL, PostgreSQL, SQL 
 
 ## Links
 
-- [The official website ›](https://nocodb.com/)
-- [GitHub ›](https://github.com/nocodb/nocodb)
+- [The official website](https://nocodb.com/)
+- [GitHub](https://github.com/nocodb/nocodb)

--- a/docs/services/observium.md
+++ b/docs/services/observium.md
@@ -5,14 +5,14 @@ description: "Monitor networks on Coolify with Observium for SNMP monitoring, de
 
 <ZoomableImage src="/docs/images/services/observium-logo.webp" alt="Observium Logo logo" />
 
-
 ## What is Observium?
+
 Observium is a comprehensive network monitoring platform designed to deliver powerful monitoring capabilities, combined with an elegant and intuitive user interface.
 
 ## Screenshots
-<ZoomableImage src="/docs/images/services/observium-screenshots.webp" alt="Observium interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/observium-screenshots.webp" alt="Observium interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://docs.observium.org/?utm_source=coolify.io)
+- [The official website](https://docs.observium.org/?utm_source=coolify.io)

--- a/docs/services/odoo.md
+++ b/docs/services/odoo.md
@@ -4,6 +4,7 @@ description: "Deploy Odoo ERP on Coolify for integrated business management with
 ---
 
 # What is Odoo?
+
 Odoo is an open source ERP and CRM software.
 
 ## Screenshots
@@ -14,5 +15,5 @@ Odoo is an open source ERP and CRM software.
 
 ## Links
 
-- [The official website ›](https://www.odoo.com/)
-- [GitHub ›](https://github.com/odoo/odoo)
+- [The official website](https://www.odoo.com/)
+- [GitHub](https://github.com/odoo/odoo)

--- a/docs/services/ollama.md
+++ b/docs/services/ollama.md
@@ -5,7 +5,6 @@ description: "Run Ollama on Coolify for local LLM hosting supporting Llama, Mist
 
 <ZoomableImage src="/docs/images/services/ollama-logo.webp" alt="Ollama dashboard" />
 
-
 ## What is Ollama?
 
 Ollama is a lightweight and efficient server for running large language models (LLMs) on your local machine or in the cloud.
@@ -13,9 +12,10 @@ Ollama is a lightweight and efficient server for running large language models (
 It includes OpenWebUI, a web-based interface for interacting with the models.
 
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/ollama.gif" alt="Ollama dashboard" />
 
 ## Links
 
-- [The official website ›](https://ollama.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/ollama/ollama?utm_source=coolify.io)
+- [The official website](https://ollama.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/ollama/ollama?utm_source=coolify.io)

--- a/docs/services/once-campfire.md
+++ b/docs/services/once-campfire.md
@@ -20,8 +20,8 @@ expect, including:
 
 ## Links
 
-- [Official website ↗](https://once.com/campfire?utm_source=coolify.io)
-- [GitHub ↗](https://github.com/basecamp/once-campfire?utm_source=coolify.io)
+- [Official website](https://once.com/campfire?utm_source=coolify.io)
+- [GitHub](https://github.com/basecamp/once-campfire?utm_source=coolify.io)
 
 ## Configuration
 

--- a/docs/services/onetime-secret.md
+++ b/docs/services/onetime-secret.md
@@ -5,12 +5,11 @@ description: "Share secrets securely on Coolify with One-Time Secret for encrypt
 
 <ZoomableImage src="/docs/images/services/onetime-secret-logo.webp" alt="Onetime Secret Logo logo" />
 
-
 ## What is Onetime Secret?
-A onetime secret is a link that can be viewed only once. A single-use URL.
 
+A onetime secret is a link that can be viewed only once. A single-use URL.
 
 ## Links
 
-- [The official website ›](https://onetimesecret.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/onetimesecret/onetimesecret?utm_source=coolify.io)
+- [The official website](https://onetimesecret.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/onetimesecret/onetimesecret?utm_source=coolify.io)

--- a/docs/services/openblocks.md
+++ b/docs/services/openblocks.md
@@ -13,5 +13,5 @@ OpenBlocks is an open source low-code platform.
 
 ## Links
 
-- [The official website ›](https://www.openblocks.dev/)
-- [GitHub ›](https://github.com/openblocks-dev/openblocks)
+- [The official website](https://www.openblocks.dev/)
+- [GitHub](https://github.com/openblocks-dev/openblocks)

--- a/docs/services/openpanel.md
+++ b/docs/services/openpanel.md
@@ -13,5 +13,5 @@ OpenPanel is an open-source alternative to Mixpanel and Plausible for product an
 
 ## Links
 
-- [The official website ›](https://openpanel.dev?utm_source=coolify.io)
-- [GitHub ›](https://github.com/Openpanel-dev/openpanel?utm_source=coolify.io)
+- [The official website](https://openpanel.dev?utm_source=coolify.io)
+- [GitHub](https://github.com/Openpanel-dev/openpanel?utm_source=coolify.io)

--- a/docs/services/orangehrm.md
+++ b/docs/services/orangehrm.md
@@ -5,12 +5,11 @@ description: "Manage HR on Coolify with OrangeHRM for employee records, leave ma
 
 <ZoomableImage src="/docs/images/services/orangehrm-logo.webp" alt="Orangehrm Logo logo" />
 
-
 ## What is OrangeHRM?
-OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures all the essential functionalities required for any enterprise.
 
+OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures all the essential functionalities required for any enterprise.
 
 ## Links
 
-- [The official website ›](https://orangehrm.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/orangehrm/orangehrm?utm_source=coolify.io)
+- [The official website](https://orangehrm.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/orangehrm/orangehrm?utm_source=coolify.io)

--- a/docs/services/outline.md
+++ b/docs/services/outline.md
@@ -13,5 +13,5 @@ Outline is an open-source collaboration tool that allows you to create and share
 
 ## Links
 
-- [The official website ›](https://getoutline.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/outline/outline?utm_source=coolify.io)
+- [The official website](https://getoutline.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/outline/outline?utm_source=coolify.io)

--- a/docs/services/overseerr.md
+++ b/docs/services/overseerr.md
@@ -5,7 +5,6 @@ description: "Deploy Overseerr on Coolify for Plex/Jellyfin media requests with 
 
 <ZoomableImage src="/docs/images/services/overseerr-logo.svg" alt="Overseerr dashboard" />
 
-
 ## What is Overseerr?
 
 Overseerr is a request management and media discovery tool built to work with your existing Plex ecosystem.
@@ -16,5 +15,5 @@ Overseerr is a request management and media discovery tool built to work with yo
 
 ## Links
 
-- [The official website ›](https://overseerr.dev/)
-- [GitHub ›](https://github.com/sct/overseerr)
+- [The official website](https://overseerr.dev/)
+- [GitHub](https://github.com/sct/overseerr)

--- a/docs/services/pairdrop.md
+++ b/docs/services/pairdrop.md
@@ -11,5 +11,5 @@ Pairdrop is a self-hosted file sharing and collaboration platform, offering secu
 
 ## Links
 
-- [The official website ›](https://pairdrop.net/)
-- [GitHub ›](https://github.com/schlagmichdoch/pairdrop)
+- [The official website](https://pairdrop.net/)
+- [GitHub](https://github.com/schlagmichdoch/pairdrop)

--- a/docs/services/passbolt.md
+++ b/docs/services/passbolt.md
@@ -5,17 +5,17 @@ description: "Deploy Passbolt on Coolify for team password management with end-t
 
 <ZoomableImage src="/docs/images/services/passbolt.webp" alt="Passbolt Logo logo" />
 
-
 ## What is Passbolt?
-Passbolt is an open source credential platform for modern teams. 
+
+Passbolt is an open source credential platform for modern teams.
 
 A versatile, battle-tested solution to manage and collaborate on passwords, accesses, and secrets. All in one.
 
-
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/passbolt-screenshot.webp" alt="Passbolt interface screenshot" />
 
-
 ## Links
-- [The official website ›](https://www.passbolt.com/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/passbolt?utm_source=coolify.io)
+
+- [The official website](https://www.passbolt.com/?utm_source=coolify.io)
+- [GitHub](https://github.com/passbolt?utm_source=coolify.io)

--- a/docs/services/paymenter.md
+++ b/docs/services/paymenter.md
@@ -16,9 +16,11 @@ Paymenter is an open-source billing platform tailored for hosting companies. It 
 3. Set the correct app URL via the terminal:
 
 Select the Paymenter container and run the following command:
-   ```bash
-   php artisan app:init
-   ```
+
+```bash
+php artisan app:init
+```
+
 4. Create the first admin user:
    ```bash
    php artisan app:user:create
@@ -26,6 +28,6 @@ Select the Paymenter container and run the following command:
 
 ## Links
 
-- [The official website ›](https://paymenter.org/)
-- [GitHub ›](https://github.com/Paymenter/Paymenter)
-- [Demo ›](https://demo.paymenter.org/)
+- [The official website](https://paymenter.org/)
+- [GitHub](https://github.com/Paymenter/Paymenter)
+- [Demo](https://demo.paymenter.org/)

--- a/docs/services/penpot.md
+++ b/docs/services/penpot.md
@@ -3,7 +3,6 @@ title: "Penpot"
 description: "Design on Coolify with Penpot open-source Figma alternative for prototyping, collaboration, SVG-based design, and web-based UI/UX workflows."
 ---
 
-
 ![Penpot](https://camo.githubusercontent.com/119ae16473fdd30f3fa077eb2639e9e2639cb3297c5e50c226c0eb25a82ea00d/68747470733a2f2f70656e706f742e6170702f696d616765732f726561646d652f6769746875622d6461726b2d6d6f64652e706e67)
 
 ## What is Penpot?
@@ -18,5 +17,5 @@ Penpot is an open-source design and prototyping tool that empowers teams to crea
 
 ## Links
 
-- [The official website ›](https://penpot.app/)
-- [GitHub ›](https://github.com/penpot/penpot)
+- [The official website](https://penpot.app/)
+- [GitHub](https://github.com/penpot/penpot)

--- a/docs/services/pgbackweb.md
+++ b/docs/services/pgbackweb.md
@@ -5,16 +5,15 @@ description: "Backup PostgreSQL on Coolify with pgBackWeb for database backups, 
 
 <ZoomableImage src="/docs/images/services/pgbackweb.webp" alt="Pgbackweb Logo logo" />
 
-
 ## What is PG Back Web?
-Effortless PostgreSQL backups with a user-friendly web interface! 
 
+Effortless PostgreSQL backups with a user-friendly web interface!
 
 ## Screenshots
-<ZoomableImage src="/docs/images/services/pgbackweb-screenshots.webp" alt="Pgbackweb interface screenshot" />
 
+<ZoomableImage src="/docs/images/services/pgbackweb-screenshots.webp" alt="Pgbackweb interface screenshot" />
 
 ## Links
 
-- [The official website ›](https://github.com/eduardolat/pgbackweb?utm_source=coolify.io)
-- [GitHub ›](https://github.com/eduardolat/pgbackweb?utm_source=coolify.io)
+- [The official website](https://github.com/eduardolat/pgbackweb?utm_source=coolify.io)
+- [GitHub](https://github.com/eduardolat/pgbackweb?utm_source=coolify.io)

--- a/docs/services/phpmyadmin.md
+++ b/docs/services/phpmyadmin.md
@@ -11,5 +11,5 @@ phpMyAdmin is a free and open-source administration tool for MySQL and MariaDB.
 
 ## Links
 
-- [The official website ›](https://www.phpmyadmin.net/)
-- [GitHub ›](https://github.com/phpmyadmin/phpmyadmin)
+- [The official website](https://www.phpmyadmin.net/)
+- [GitHub](https://github.com/phpmyadmin/phpmyadmin)

--- a/docs/services/pi-hole.md
+++ b/docs/services/pi-hole.md
@@ -13,5 +13,5 @@ Pi-hole is a network-wide ad blocker that acts as a DNS sinkhole, protecting you
 
 ## Links
 
-- [The official website ›](https://pi-hole.net?utm_source=coolify.io)
-- [GitHub ›](https://github.com/pi-hole/pi-hole?utm_source=coolify.io)
+- [The official website](https://pi-hole.net?utm_source=coolify.io)
+- [GitHub](https://github.com/pi-hole/pi-hole?utm_source=coolify.io)

--- a/docs/services/pingvinshare.md
+++ b/docs/services/pingvinshare.md
@@ -13,4 +13,4 @@ PingvinShare is a self-hosted file sharing platform that combines lightness and 
 
 ## Links
 
-- [GitHub ›](https://github.com/stonith404/pingvin-share?utm_source=coolify.io)
+- [GitHub](https://github.com/stonith404/pingvin-share?utm_source=coolify.io)

--- a/docs/services/plane.md
+++ b/docs/services/plane.md
@@ -3,7 +3,6 @@ title: "Plane"
 description: "Manage projects on Coolify with Plane for issue tracking, sprints, roadmaps, and modern project management for software development teams."
 ---
 
-
 ![Plane](https://camo.githubusercontent.com/82feb9c8f8212561ecebe55b26622afa2b11e9943c698d3a28789f0bed77b651/68747470733a2f2f706c616e652d6d61726b6574696e672e73332e61702d736f7574682d312e616d617a6f6e6177732e636f6d2f706c616e652d726561646d652f706c616e655f6c6f676f5f2e77656270)
 
 ## What is Plane?
@@ -19,5 +18,5 @@ Plane is a free and open-source project management tool that empowers teams to c
 
 ## Links
 
-- [The official website ›](https://plane.so)
-- [GitHub ›](https://github.com/makeplane/plane)
+- [The official website](https://plane.so)
+- [GitHub](https://github.com/makeplane/plane)

--- a/docs/services/plausible.md
+++ b/docs/services/plausible.md
@@ -29,5 +29,5 @@ Due to trademark issues, we can't provide a fully automated one-click Service in
 
 ## Links
 
-- [The official website ›](https://plausible.io/)
-- [GitHub ›](https://github.com/plausible/analytics)
+- [The official website](https://plausible.io/)
+- [GitHub](https://github.com/plausible/analytics)

--- a/docs/services/plex.md
+++ b/docs/services/plex.md
@@ -26,5 +26,5 @@ Available on almost any device, Plex is the first-and-only streaming platform to
 
 ## Links
 
-- [The official website ›](https://www.plex.tv/)
-- [GitHub ›](https://github.com/plexinc/pms-docker)
+- [The official website](https://www.plex.tv/)
+- [GitHub](https://github.com/plexinc/pms-docker)

--- a/docs/services/plunk.md
+++ b/docs/services/plunk.md
@@ -3,7 +3,6 @@ title: "Plunk"
 description: "Send emails on Coolify with Plunk for transactional email API, templates, analytics, and developer-friendly email delivery service."
 ---
 
-
 ![Plunk](https://raw.githubusercontent.com/useplunk/plunk/main/assets/card.png)
 
 ## What is Plunk?
@@ -18,5 +17,5 @@ Plunk is an open-source email platform for AWS.
 
 ## Links
 
-- [The official website ›](https://useplunk.com)
-- [GitHub ›](https://github.com/useplunk/plunk)
+- [The official website](https://useplunk.com)
+- [GitHub](https://github.com/useplunk/plunk)

--- a/docs/services/pocketbase.md
+++ b/docs/services/pocketbase.md
@@ -3,7 +3,6 @@ title: "PocketBase"
 description: "Deploy PocketBase on Coolify for instant backend with database, authentication, file storage, real-time subscriptions in single executable."
 ---
 
-
 ![PocketBase](https://camo.githubusercontent.com/3b198a3ea92b78b9f56f6ec7c2eea0d81ee57ec8b4e2420cde3e1fecedcbc2c7/68747470733a2f2f692e696d6775722e636f6d2f3571696d6e6d352e706e67)
 
 ## What is PocketBase?
@@ -12,5 +11,5 @@ PocketBase is an open-source backend-as-a-service (BaaS) that empowers developer
 
 ## Links
 
-- [The official website ›](https://pocketbase.io)
-- [GitHub ›](https://github.com/pocketbase/pocketbase)
+- [The official website](https://pocketbase.io)
+- [GitHub](https://github.com/pocketbase/pocketbase)

--- a/docs/services/posthog.md
+++ b/docs/services/posthog.md
@@ -3,7 +3,6 @@ title: "PostHog"
 description: "Run PostHog analytics on Coolify for product analytics, feature flags, session replay, A/B testing, and user behavior tracking platform."
 ---
 
-
 ![PostHog](https://user-images.githubusercontent.com/65415371/205059737-c8a4f836-4889-4654-902e-f302b187b6a0.png)
 
 ::: danger SERVICE TEMPORARILY DISABLED
@@ -16,5 +15,5 @@ The single platform to analyze, test, observe, and deploy new features
 
 ## Links
 
-- [The official website ›](https://posthog.com)
-- [GitHub ›](https://github.com/PostHog/posthog)
+- [The official website](https://posthog.com)
+- [GitHub](https://github.com/PostHog/posthog)

--- a/docs/services/prefect.md
+++ b/docs/services/prefect.md
@@ -5,7 +5,6 @@ description: "Orchestrate workflows on Coolify with Prefect for data pipelines, 
 
 <ZoomableImage src="/docs/images/services/prefect.webp" alt="Prefect dashboard" />
 
-
 ## What is Prefect?
 
 Prefect is an orchestration and observability platform that empowers developers to build and scale workflows quickly.
@@ -14,8 +13,7 @@ Prefect is an orchestration and observability platform that empowers developers 
 
 <ZoomableImage src="/docs/images/services/prefect.avif" alt="Prefect dashboard" />
 
-
 ## Links
 
-- [The official website ›](https://www.prefect.io?utm_source=coolify.io)
-- [GitHub ›](https://github.com/PrefectHQ/prefect?utm_source=coolify.io)
+- [The official website](https://www.prefect.io?utm_source=coolify.io)
+- [GitHub](https://github.com/PrefectHQ/prefect?utm_source=coolify.io)

--- a/docs/services/prowlarr.md
+++ b/docs/services/prowlarr.md
@@ -5,7 +5,6 @@ description: "Manage indexers on Coolify with Prowlarr for centralized torrent a
 
 <ZoomableImage src="/docs/images/services/prowlarr.svg" alt="Prowlarr dashboard" />
 
-
 ## What is Prowlarr?
 
 Prowlarr is an indexer manager/proxy built on the popular \*arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).
@@ -16,5 +15,5 @@ Prowlarr is an indexer manager/proxy built on the popular \*arr .net/reactjs bas
 
 ## Links
 
-- [The official website ›](https://prowlarr.com/)
-- [GitHub ›](https://github.com/Prowlarr/Prowlarr)
+- [The official website](https://prowlarr.com/)
+- [GitHub](https://github.com/Prowlarr/Prowlarr)

--- a/docs/services/pterodactyl.md
+++ b/docs/services/pterodactyl.md
@@ -20,10 +20,9 @@ Stop settling for less. Make game servers a first-class citizen on your platform
 <ZoomableImage src="/docs/images/services/pterodactyl-screenshot-5.webp" alt="Pterodactyl interface screenshot" />
 <ZoomableImage src="/docs/images/services/pterodactyl-screenshot-6.webp" alt="Pterodactyl interface screenshot" />
 
-
 ## Links
 
-- [The official website ›](https://pterodactyl.io)
-- [GitHub ›](https://github.com/pterodactyl/panel)
-- [Documentation ›](https://pterodactyl.io/project/introduction.html)
-- [Community Discord ›](https://discord.gg/pterodactyl)
+- [The official website](https://pterodactyl.io)
+- [GitHub](https://github.com/pterodactyl/panel)
+- [Documentation](https://pterodactyl.io/project/introduction.html)
+- [Community Discord](https://discord.gg/pterodactyl)

--- a/docs/services/qdrant.md
+++ b/docs/services/qdrant.md
@@ -5,13 +5,11 @@ description: "Deploy Qdrant vector database on Coolify for AI embeddings, semant
 
 <ZoomableImage src="/docs/images/services/qdrant-logo.svg" alt="Qdrant dashboard" />
 
-
 ## What is Qdrant?
 
 Qdrant is an AI-native vector database and a semantic search engine. You can use it to extract meaningful information from unstructured data.
 
-
 ## Links
 
-- [The official website ›](https://qdrant.tech/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/qdrant/qdrant?utm_source=coolify.io)
+- [The official website](https://qdrant.tech/?utm_source=coolify.io)
+- [GitHub](https://github.com/qdrant/qdrant?utm_source=coolify.io)

--- a/docs/services/rabbitmq.md
+++ b/docs/services/rabbitmq.md
@@ -3,7 +3,6 @@ title: "RabbitMQ"
 description: "Host RabbitMQ message broker on Coolify for reliable messaging, queuing, routing, and distributed system communication with AMQP protocol."
 ---
 
-
 ![RabbitMQ](https://www.rabbitmq.com/img/rabbitmq-logo-with-name.svg)
 
 ## What is RabbitMQ?
@@ -12,5 +11,5 @@ RabbitMQ is an open-source message broker software that implements the Advanced 
 
 ## Links
 
-- [The official website ›](https://rabbitmq.com)
-- [GitHub ›](https://github.com/rabbitmq/rabbitmq-server)
+- [The official website](https://rabbitmq.com)
+- [GitHub](https://github.com/rabbitmq/rabbitmq-server)

--- a/docs/services/radarr.md
+++ b/docs/services/radarr.md
@@ -15,5 +15,5 @@ See all your upcoming movies in one convenient location. Manual Search Find all 
 
 ## Links
 
-- [The official website ›](https://radarr.video/)
-- [GitHub ›](https://github.com/Radarr/Radarr)
+- [The official website](https://radarr.video/)
+- [GitHub](https://github.com/Radarr/Radarr)

--- a/docs/services/reactive-resume.md
+++ b/docs/services/reactive-resume.md
@@ -5,8 +5,6 @@ description: "Build resumes on Coolify with Reactive Resume for free resume buil
 
 <ZoomableImage src="/docs/images/services/rxresume-logo.svg" alt="Reactive Resume dashboard" />
 
-
-
 ![Reactive Resume](https://camo.githubusercontent.com/34a172f62213af3abf30c655d1a42744d57019f3866b321aa83d9f4d403d5248/68747470733a2f2f692e696d6775722e636f6d2f464663346e795a2e6a7067)
 
 ## What is Reactive Resume?
@@ -15,5 +13,5 @@ Reactive Resume is an open-source resume builder that allows you to create a pro
 
 ## Links
 
-- [The official website ›](https://rxresu.me/)
-- [GitHub ›](https://github.com/AmruthPillai/Reactive-Resume)
+- [The official website](https://rxresu.me/)
+- [GitHub](https://github.com/AmruthPillai/Reactive-Resume)

--- a/docs/services/rocketchat.md
+++ b/docs/services/rocketchat.md
@@ -3,7 +3,6 @@ title: "Rocket.Chat"
 description: "Deploy Rocket.Chat on Coolify for team communication, video conferencing, file sharing, and open-source Slack alternative with federation."
 ---
 
-
 ![Rocket Chat](https://raw.githubusercontent.com/RocketChat/Rocket.Chat.Artwork/master/Logos/2020/png/logo-horizontal-red.png)
 
 ## What is Rocket.Chat?
@@ -18,5 +17,5 @@ Rocket.Chat is an open-source team communication platform that allows you to com
 
 ## Links
 
-- [The official website ›](https://rocket.chat)
-- [GitHub ›](https://github.com/RocketChat/Rocket.Chat)
+- [The official website](https://rocket.chat)
+- [GitHub](https://github.com/RocketChat/Rocket.Chat)

--- a/docs/services/rybbit.md
+++ b/docs/services/rybbit.md
@@ -11,7 +11,7 @@ Rybbit is a next-gen, open source, lightweight, cookieless web & product analyti
 
 ## Configuration
 
-- set frontend URL. 
+- set frontend URL.
 - set backend URL to `$frontend_URL/api` and uncheck the "Strip Prefixes" option.
 
 # Screenshots
@@ -20,5 +20,5 @@ Rybbit is a next-gen, open source, lightweight, cookieless web & product analyti
 
 ## Links
 
-- [Official Website ›](https://www.rybbit.io/)
-- [GitHub ›](https://github.com/rybbit-io/rybbit)
+- [Official Website](https://www.rybbit.io/)
+- [GitHub](https://github.com/rybbit-io/rybbit)

--- a/docs/services/ryot.md
+++ b/docs/services/ryot.md
@@ -5,12 +5,11 @@ description: "Track media on Coolify with Ryot for movies, TV shows, books, vide
 
 <ZoomableImage src="/docs/images/services/ryot-logo.svg" alt="Ryot Logo logo" />
 
-
 ## What is Ryot?
-A self hosted platform for tracking various facets of your life - media, fitness etc.
 
+A self hosted platform for tracking various facets of your life - media, fitness etc.
 
 ## Links
 
-- [The official website ›](https://ryot.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/ignisda/ryot?utm_source=coolify.io)
+- [The official website](https://ryot.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/ignisda/ryot?utm_source=coolify.io)

--- a/docs/services/seafile.md
+++ b/docs/services/seafile.md
@@ -5,14 +5,13 @@ description: "Sync files on Coolify with Seafile for secure cloud storage, team 
 
 <ZoomableImage src="/docs/images/services/seafile.webp" alt="Seafile Logo logo" />
 
-
 ## What is Seafile?
-Seafile is an open source cloud storage system for file sync, share and document collaboration. 
+
+Seafile is an open source cloud storage system for file sync, share and document collaboration.
 
 SeaDoc is an extension of Seafile that providing a lightweight online collaborative document feature.
 
-
 ## Links
 
-- [The official website ›](https://www.seafile.com/en/home/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/haiwen/seafile?utm_source=coolify.io)
+- [The official website](https://www.seafile.com/en/home/?utm_source=coolify.io)
+- [GitHub](https://github.com/haiwen/seafile?utm_source=coolify.io)

--- a/docs/services/searxng.md
+++ b/docs/services/searxng.md
@@ -11,5 +11,5 @@ SearXNG is a free internet metasearch engine which aggregates results from vario
 
 ## Links
 
-- [The official website ›](https://docs.searxng.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/searxng/searxng?utm_source=coolify.io)
+- [The official website](https://docs.searxng.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/searxng/searxng?utm_source=coolify.io)

--- a/docs/services/sequin.md
+++ b/docs/services/sequin.md
@@ -13,5 +13,5 @@ Sequin is the fastest Postgres change data capture (CDC) solution that helps you
 
 ## Links
 
-- [The official website ›](https://sequinstream.com?utm_source=coolify.io)
-- [GitHub ›](https://github.com/sequinstream/sequin?utm_source=coolify.io)
+- [The official website](https://sequinstream.com?utm_source=coolify.io)
+- [GitHub](https://github.com/sequinstream/sequin?utm_source=coolify.io)

--- a/docs/services/shlink.md
+++ b/docs/services/shlink.md
@@ -11,5 +11,5 @@ Shlink is an open-source URL shortener that allows you to create a short URL for
 
 ## Links
 
-- [The official website ›](https://shlink.io)
-- [GitHub ›](https://github.com/shlinkio/shlink)
+- [The official website](https://shlink.io)
+- [GitHub](https://github.com/shlinkio/shlink)

--- a/docs/services/slash.md
+++ b/docs/services/slash.md
@@ -3,7 +3,6 @@ title: "Slash"
 description: "Manage bookmarks on Coolify with Slash for self-hosted link shortener, collections, sharing, and personal URL management with tagging."
 ---
 
-
 ## What is Slash?
 
 An open source, self-hosted platform for sharing and managing your most frequently used links. Easily create customizable, human-readable shortcuts to streamline your link management.
@@ -14,4 +13,4 @@ An open source, self-hosted platform for sharing and managing your most frequent
 
 ## Links
 
-- [GitHub ›](https://github.com/yourselfhosted/slash)
+- [GitHub](https://github.com/yourselfhosted/slash)

--- a/docs/services/snapdrop.md
+++ b/docs/services/snapdrop.md
@@ -3,11 +3,10 @@ title: "Snapdrop"
 description: "Transfer files on Coolify with Snapdrop for local network file sharing, AirDrop-style transfers, and instant peer-to-peer file exchange."
 ---
 
-
 # What is Snapdrop?
 
 A self-hosted file-sharing service for secure and convenient file transfers, whether on a local network or the internet.
 
 ## Links
 
-- [GitHub ›](https://github.com/RobinLinus/snapdrop)
+- [GitHub](https://github.com/RobinLinus/snapdrop)

--- a/docs/services/soketi-app-manager.md
+++ b/docs/services/soketi-app-manager.md
@@ -5,18 +5,18 @@ description: "Manage Soketi apps on Coolify with application configuration, auth
 
 <ZoomableImage src="/docs/images/services/soketi-app-manager-logo.webp" alt="Soketi App Manager Logo logo" />
 
-
 ## What is Soketi App Manager ?
-Soketi App Manager provides a user-friendly interface for managing your Soketi websocket applications. 
+
+Soketi App Manager provides a user-friendly interface for managing your Soketi websocket applications.
 
 You can effortlessly manage multiple websocket applications, streamlining your app management process.
 
-
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/soketi-app-manager-screenshots-1.webp" alt="Soketi App Manager interface screenshot" />
 <br />
 <ZoomableImage src="/docs/images/services/soketi-app-manager-screenshots-2.webp" alt="Soketi App Manager interface screenshot" />
 
 ## Links
 
-- [GitHub ›](https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io)
+- [GitHub](https://github.com/rahulhaque/soketi-app-manager-filament?utm_source=coolify.io)

--- a/docs/services/sonarr.md
+++ b/docs/services/sonarr.md
@@ -15,5 +15,5 @@ Sonarr is an internet PVR for Usenet and Torrents. Features Calendar See all you
 
 ## Links
 
-- [The official website ›](https://sonarr.tv/)
-- [GitHub ›](https://github.com/Sonarr/Sonarr)
+- [The official website](https://sonarr.tv/)
+- [GitHub](https://github.com/Sonarr/Sonarr)

--- a/docs/services/statusnook.md
+++ b/docs/services/statusnook.md
@@ -5,7 +5,6 @@ description: "Monitor status on Coolify with StatusNook for uptime monitoring, s
 
 <ZoomableImage src="/docs/images/services/statusnook-logo.svg" alt="Statusnook dashboard" />
 
-
 ![Statusnook](https://github.com/goksan/statusnook/assets/17437810/ff2bb1d4-5d75-4b6e-b8d9-a7227d1aee6c)
 
 ## What is Statusnook?
@@ -14,5 +13,5 @@ Statusnook allows you to effortlessly deploy a status page and start monitoring 
 
 ## Links
 
-- [The official website ›](https://statusnook.com)
-- [GitHub ›](https://github.com/goksan/statusnook)
+- [The official website](https://statusnook.com)
+- [GitHub](https://github.com/goksan/statusnook)

--- a/docs/services/stirling-pdf.md
+++ b/docs/services/stirling-pdf.md
@@ -3,7 +3,6 @@ title: "Stirling PDF"
 description: "Process PDFs on Coolify with Stirling-PDF for merging, splitting, compression, conversion, OCR, and 50+ PDF manipulation operations."
 ---
 
-
 ![Stirling PDF](https://raw.githubusercontent.com/Stirling-Tools/Stirling-PDF/main/docs/stirling.png)
 
 ## What is Stirling PDF?
@@ -12,5 +11,5 @@ A self-hosted PDF editor for secure and convenient file transfers, whether on a 
 
 ## Links
 
-- [Official Website ›](https://stirlingpdf.com)
-- [GitHub ›](https://github.com/Stirling-Tools/Stirling-PDF)
+- [Official Website](https://stirlingpdf.com)
+- [GitHub](https://github.com/Stirling-Tools/Stirling-PDF)

--- a/docs/services/supabase.md
+++ b/docs/services/supabase.md
@@ -36,11 +36,12 @@ Then add this line
       - ${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}`
 
 To
+
 ```yaml
 supabase-db:
-  image: 'supabase/postgres:15.6.1.146'
+  image: "supabase/postgres:15.6.1.146"
   healthcheck:
-    test: 'pg_isready -U postgres -h 127.0.0.1'
+    test: "pg_isready -U postgres -h 127.0.0.1"
     interval: 5s
     timeout: 5s
     retries: 10
@@ -71,5 +72,5 @@ If your server is hosted on Hetzner, you may not need ufw-docker. Instead, you c
 
 ## Links
 
-- [Official Website ›](https://supabase.io)
-- [GitHub ›](https://github.com/supabase/supabase)
+- [Official Website](https://supabase.io)
+- [GitHub](https://github.com/supabase/supabase)

--- a/docs/services/swetrix.md
+++ b/docs/services/swetrix.md
@@ -19,7 +19,7 @@ Swetrix is a privacy-friendly, cookieless and open-source web analytics alternat
 
 ## Links
 
-- [The official website ›](https://swetrix.com)
-- [GitHub ›](https://github.com/swetrix/swetrix)
-- [Documentation ›](https://docs.swetrix.com)
-- [Community Discord ›](https://swetrix.com/discord)
+- [The official website](https://swetrix.com)
+- [GitHub](https://github.com/swetrix/swetrix)
+- [Documentation](https://docs.swetrix.com)
+- [Community Discord](https://swetrix.com/discord)

--- a/docs/services/syncthing.md
+++ b/docs/services/syncthing.md
@@ -3,7 +3,6 @@ title: "Syncthing"
 description: "Sync files on Coolify with Syncthing for continuous file synchronization, P2P data replication, and decentralized backup across devices."
 ---
 
-
 ![Syncthing](https://raw.githubusercontent.com/syncthing/syncthing/main/assets/logo-text-128.png)
 
 ## What is Syncthing?
@@ -12,5 +11,5 @@ Syncthing synchronizes files between two or more computers in real time.
 
 ## Links
 
-- [Official Website ›](https://syncthing.net)
-- [GitHub ›](https://github.com/syncthing/syncthing)
+- [Official Website](https://syncthing.net)
+- [GitHub](https://github.com/syncthing/syncthing)

--- a/docs/services/tolgee.md
+++ b/docs/services/tolgee.md
@@ -13,5 +13,5 @@ Tolgee is an open-source translation management platform that allows you to mana
 
 ## Links
 
-- [Official Website ›](https://tolgee.io)
-- [GitHub ›](https://github.com/tolgee/tolgee-platform)
+- [Official Website](https://tolgee.io)
+- [GitHub](https://github.com/tolgee/tolgee-platform)

--- a/docs/services/trigger.md
+++ b/docs/services/trigger.md
@@ -3,7 +3,6 @@ title: "Trigger"
 description: "Automate workflows on Coolify with Trigger.dev for background jobs, scheduled tasks, webhooks, and event-driven workflow automation."
 ---
 
-
 ![Trigger](https://camo.githubusercontent.com/eab9fa8c4faf6ea7b868a38aea57abf375fc43233d257bc52314409f279ce541/68747470733a2f2f696d61676564656c69766572792e6e65742f3354627261666675445a34614566384b574f6d495f772f61343564316661322d306165382d346133392d343430392d6634663933346266616530302f7075626c6963)
 
 ## What is Trigger?
@@ -12,5 +11,5 @@ Trigger is an open source Background Jobs framework for TypeScript.
 
 ## Links
 
-- [Official Website ›](https://trigger.dev)
-- [GitHub ›](https://github.com/triggerdotdev/trigger.dev)
+- [Official Website](https://trigger.dev)
+- [GitHub](https://github.com/triggerdotdev/trigger.dev)

--- a/docs/services/triliumnext.md
+++ b/docs/services/triliumnext.md
@@ -13,4 +13,4 @@ TriliumNext is a hierarchical note taking application that helps you build your 
 
 ## Links
 
-- [GitHub ›](https://github.com/TriliumNext/Trilium?utm_source=coolify.io)
+- [GitHub](https://github.com/TriliumNext/Trilium?utm_source=coolify.io)

--- a/docs/services/typesense.md
+++ b/docs/services/typesense.md
@@ -5,17 +5,16 @@ description: "Search instantly on Coolify with Typesense for typo-tolerant searc
 
 <ZoomableImage src="/docs/images/services/typesense.webp" alt="Typesense Logo logo" />
 
-
 ## What is Typesense?
+
 Typesense is an open-source, typo-tolerant search engine optimized for instant (typically sub-50ms) search-as-you-type experiences and developer productivity.
 
 If you've heard about ElasticSearch or Algolia, a good way to think about Typesense is that it is:
+
 - An open source alternative to Algolia, with some key quirks solved and
 - An easier-to-use batteries-included alternative to ElasticSearch
 
-
-
 ## Links
 
-- [The official website ›](https://typesense.org/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/typesense/typesense?utm_source=coolify.io)
+- [The official website](https://typesense.org/?utm_source=coolify.io)
+- [GitHub](https://github.com/typesense/typesense?utm_source=coolify.io)

--- a/docs/services/umami.md
+++ b/docs/services/umami.md
@@ -19,5 +19,5 @@ Umami is an open source, privacy-focused alternative to Google Analytics.
 
 ## Links
 
-- [Official Website ›](https://umami.is)
-- [GitHub ›](https://github.com/umami-software/umami)
+- [Official Website](https://umami.is)
+- [GitHub](https://github.com/umami-software/umami)

--- a/docs/services/unleash.md
+++ b/docs/services/unleash.md
@@ -5,8 +5,6 @@ description: "Manage features on Coolify with Unleash for feature toggles, A/B t
 
 <ZoomableImage src="/docs/images/services/unleash.svg" alt="Unleash dashboard" />
 
-
-
 ![Unleash](https://raw.githubusercontent.com/Unleash/unleash/main/.github/github_header_opaque_landscape.svg)
 
 ## What is Unleash?
@@ -19,5 +17,5 @@ Unleash is an open source feature flagging service.
 
 ## Links
 
-- [Official Website ›](https://getunleash.io)
-- [GitHub ›](https://github.com/unleash/unleash)
+- [Official Website](https://getunleash.io)
+- [GitHub](https://github.com/unleash/unleash)

--- a/docs/services/unstructured.md
+++ b/docs/services/unstructured.md
@@ -21,4 +21,4 @@ Unstructured provides a platform and tools to ingest and process unstructured do
 
 ## Links
 
-- [GitHub ›](https://github.com/Unstructured-IO/unstructured-api?utm_source=coolify.io)
+- [GitHub](https://github.com/Unstructured-IO/unstructured-api?utm_source=coolify.io)

--- a/docs/services/uptime-kuma.md
+++ b/docs/services/uptime-kuma.md
@@ -13,4 +13,4 @@ Uptime Kuma is an easy-to-use, privacy-focused uptime monitoring service.
 
 ## Links
 
-- [GitHub ›](https://github.com/louislam/uptime-kuma?tab=readme-ov-file)
+- [GitHub](https://github.com/louislam/uptime-kuma?tab=readme-ov-file)

--- a/docs/services/vaultwarden.md
+++ b/docs/services/vaultwarden.md
@@ -8,6 +8,7 @@ description: "Store passwords on Coolify with Vaultwarden unofficial Bitwarden s
 ## What is Vaultwarden?
 
 Vaultwarden is an open source, self-hosted password manager.
+
 ## Links
 
-- [GitHub ›](https://github.com/dani-garcia/vaultwarden)
+- [GitHub](https://github.com/dani-garcia/vaultwarden)

--- a/docs/services/vert.md
+++ b/docs/services/vert.md
@@ -5,12 +5,11 @@ description: "Deploy Vert.x on Coolify for reactive applications, microservices,
 
 <ZoomableImage src="/docs/images/services/vert.webp" alt="Vert Logo logo" />
 
-
 ## What is Vert?
-VERT is a file conversion utility that uses WebAssembly to convert files on your device instead of a cloud. 
 
+VERT is a file conversion utility that uses WebAssembly to convert files on your device instead of a cloud.
 
 ## Links
 
-- [The official website ›](https://vert.sh/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/VERT-sh/VERT?utm_source=coolify.io)
+- [The official website](https://vert.sh/?utm_source=coolify.io)
+- [GitHub](https://github.com/VERT-sh/VERT?utm_source=coolify.io)

--- a/docs/services/vikunja.md
+++ b/docs/services/vikunja.md
@@ -11,10 +11,9 @@ Vikunja is an open source, self-hosted, task management application.
 
 ## Screenshots
 
-
 ![Vikunja Preview](https://vikunja.io/_astro/09-task-detail-dark.ppLbej6M_ZzaSch.avif)
 
 ## Links
 
-- [Official Website ›](https://vikunja.io)
-- [GitHub ›](https://kolaente.dev/vikunja/vikunja)
+- [Official Website](https://vikunja.io)
+- [GitHub](https://kolaente.dev/vikunja/vikunja)

--- a/docs/services/weaviate.md
+++ b/docs/services/weaviate.md
@@ -11,5 +11,5 @@ Weaviate (we-vee-eight) is an open source, AI-native vector database. Use this d
 
 ## Links
 
-- [The official website ›](https://weaviate.io/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/weaviate/weaviate?utm_source=coolify.io)
+- [The official website](https://weaviate.io/?utm_source=coolify.io)
+- [GitHub](https://github.com/weaviate/weaviate?utm_source=coolify.io)

--- a/docs/services/weblate.md
+++ b/docs/services/weblate.md
@@ -3,7 +3,6 @@ title: "Weblate"
 description: "Translate software on Coolify with Weblate for continuous localization, collaboration, version control, and open-source translation management."
 ---
 
-
 ![Weblate](https://camo.githubusercontent.com/2143626e8516dcee05bd0dab52c5e981bcd79defc10a6a56a7384b747f49a6d3/68747470733a2f2f732e7765626c6174652e6f72672f63646e2f4c6f676f2d4461726b746578742d626f72646572732e706e67)
 
 ## What is Weblate?
@@ -16,5 +15,5 @@ Weblate is an open source, self-hosted, translation management system.
 
 ## Links
 
-- [Official Website ›](https://weblate.org)
-- [GitHub ›](https://github.com/WeblateOrg/weblate)
+- [Official Website](https://weblate.org)
+- [GitHub](https://github.com/WeblateOrg/weblate)

--- a/docs/services/whoogle.md
+++ b/docs/services/whoogle.md
@@ -3,7 +3,6 @@ title: "Whoogle"
 description: "Search Google privately on Coolify with Whoogle for anonymous Google searches without tracking, ads, or AMP with self-hosted proxy."
 ---
 
-
 ![Whoogle](https://raw.githubusercontent.com/benbusby/whoogle-search/main/docs/banner.png)
 
 ## What is Whoogle?
@@ -12,4 +11,4 @@ Whoogle is an open source, self-hosted, privacy-respecting, ad-free, and de-goog
 
 ## Links
 
-- [GitHub ›](https://github.com/benbusby/whoogle-search)
+- [GitHub](https://github.com/benbusby/whoogle-search)

--- a/docs/services/windmill.md
+++ b/docs/services/windmill.md
@@ -19,5 +19,5 @@ Windmill is an open-source developer platform to power your entire infra and tur
 
 ## Links
 
-- [Official Website ›](https://windmill.dev)
-- [GitHub ›](https://github.com/windmill-labs/windmill)
+- [Official Website](https://windmill.dev)
+- [GitHub](https://github.com/windmill-labs/windmill)

--- a/docs/services/wordpress.md
+++ b/docs/services/wordpress.md
@@ -10,13 +10,13 @@ description: "Run WordPress on Coolify for blogging, CMS, e-commerce with plugin
 WordPress is a free and open-source content management system written in PHP and paired with a MySQL/MariaDB database.
 It is used for creating websites, blogs, and applications.
 
-
 ## Links
 
-- [The official website ›](https://wordpress.org)
-- [GitHub ›](https://github.com/WordPress/WordPress)
+- [The official website](https://wordpress.org)
+- [GitHub](https://github.com/WordPress/WordPress)
 
 ## FAQ
+
 ### How to increase the upload size limit?
 
 You can increase the upload size limit by following these steps:
@@ -37,7 +37,6 @@ php_value max_input_time 300
 4. Reload the website in your browser. The changes should be applied automatically.
 
 ### How to Fix a Redirection Loop in WordPress?
-
 
 If your WordPress site is stuck in a redirection loop, follow these steps to resolve the issue:
 

--- a/docs/services/yamtrack.md
+++ b/docs/services/yamtrack.md
@@ -5,18 +5,17 @@ description: "Track time on Coolify with YAMTrack for project time logging, invo
 
 <ZoomableImage src="/docs/images/services/yamtrack.webp" alt="Yamtrack Logo logo" />
 
-
 ## What is Yamtrack?
+
 Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.
 
-
 ## Screenshots
+
 <ZoomableImage src="/docs/images/services/yamtrack-screenshots-1.webp" alt="Yamtrack interface screenshot" />
 <br />
 <ZoomableImage src="/docs/images/services/yamtrack-screenshots-2.webp" alt="Yamtrack interface screenshot" />
 
-
 ## Links
 
-- [The official website ›](https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io)
-- [GitHub ›](https://github.com/FuzzyGrim/Yamtrack?utm_source=coolify.io)
+- [The official website](https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io)
+- [GitHub](https://github.com/FuzzyGrim/Yamtrack?utm_source=coolify.io)

--- a/docs/services/zipline.md
+++ b/docs/services/zipline.md
@@ -3,13 +3,12 @@ title: "Zipline"
 description: "Share files on Coolify with Zipline for screenshot sharing, file uploads, URL shortening, and personal media hosting with embeds."
 ---
 
-
 ![Zipline](https://raw.githubusercontent.com/diced/zipline/trunk/public/zipline_small.png)
 
 ## What is Zipline?
 
 The next generation ShareX / File upload server
-A ShareX/file upload server that is easy to use, packed with features, and with an easy setup! 
+A ShareX/file upload server that is easy to use, packed with features, and with an easy setup!
 
 ## Screenshots
 
@@ -19,6 +18,5 @@ A ShareX/file upload server that is easy to use, packed with features, and with 
 
 ## Links
 
-- [The official website ›](https://zipline.diced.sh/?utm_source=coolify.io)
-- [GitHub ›](https://github.com/diced/zipline?utm_source=coolify.io)
-
+- [The official website](https://zipline.diced.sh/?utm_source=coolify.io)
+- [GitHub](https://github.com/diced/zipline?utm_source=coolify.io)

--- a/docs/troubleshoot/applications/bad-gateway.md
+++ b/docs/troubleshoot/applications/bad-gateway.md
@@ -59,4 +59,4 @@ If your deployed application **maybe** works when you access it via your server�
 
 ## Support
 
-If these steps don’t solve the issue, consider reaching out for further assistance by joining our [Discord community ↗](https://coolify.io/discord) and sharing your app logs, coolify proxy logs, configuration screenshots, and details of the troubleshooting steps you’ve already tried.
+If these steps don’t solve the issue, consider reaching out for further assistance by joining our [Discord community](https://coolify.io/discord) and sharing your app logs, coolify proxy logs, configuration screenshots, and details of the troubleshooting steps you’ve already tried.

--- a/docs/troubleshoot/applications/gateway-timeout.md
+++ b/docs/troubleshoot/applications/gateway-timeout.md
@@ -153,7 +153,7 @@ command:
   - "--entrypoints.https.transport.respondingTimeouts.idleTimeout=5m"
 ```
 
-Read more about Traefik timeouts in the [official documentation ↗](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#timeout).
+Read more about Traefik timeouts in the [official documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#timeout).
 
 ##### For Caddy
 
@@ -169,7 +169,7 @@ caddy.servers.timeouts.write=300s
 caddy.servers.timeouts.idle=5m
 ```
 
-Read more about Caddy timeouts in the [official documentation ↗](https://caddyserver.com/docs/caddyfile/options#timeouts).
+Read more about Caddy timeouts in the [official documentation](https://caddyserver.com/docs/caddyfile/options#timeouts).
 
 ##### For Nginx (One-Click Databases)
 
@@ -246,5 +246,5 @@ If these solutions don't resolve your gateway timeout issues:
    docker logs <your-container-name> --tail 200 > app-logs.txt
    ```
 
-2. Join our [Discord Community ↗](https://coolify.io/discord)
+2. Join our [Discord Community](https://coolify.io/discord)
 3. Share your configuration, logs, and the specific steps you've tried

--- a/docs/troubleshoot/applications/no-available-server.md
+++ b/docs/troubleshoot/applications/no-available-server.md
@@ -231,7 +231,7 @@ curl -f http://localhost:3000/health
 
 ## When to Seek Help
 
-If none of these solutions work, join our [Discord community ↗](https://coolify.io/discord) and provide:
+If none of these solutions work, join our [Discord community](https://coolify.io/discord) and provide:
 
 - Application logs
 - Coolify proxy logs

--- a/docs/troubleshoot/dashboard/dashboard-inaccessible.md
+++ b/docs/troubleshoot/dashboard/dashboard-inaccessible.md
@@ -4,8 +4,8 @@ description: Fix Coolify dashboard access issues by checking proxy status, conta
 ---
 
 # Coolify Dashboard Inaccessible
-Having trouble accessing your Coolify dashboard? follow these steps to diagnose and resolve the issue.
 
+Having trouble accessing your Coolify dashboard? follow these steps to diagnose and resolve the issue.
 
 ## 1. Determine Your Access Method
 
@@ -14,76 +14,87 @@ First, ask yourself: **How are you trying to access the dashboard?**
 - **Custom Domain:** If you’re using the domain you set up for your Coolify dashboard, the problem might be with the Coolify proxy.
 - **Direct Server IP:** If you’re using your server’s IP address, the issue could be related to your server or container status.
 
-
 ## 2. Test with Your Server’s IP Address
 
 ### A. Open Your Firewall Port
+
 - **Step:** Make sure that port `8000` is open on your firewall.
 - **Why:** This allows direct access to the Coolify dashboard without any proxy interference.
 
 ### B. Access the Dashboard Directly
-- **Step:** Open your web browser and go to: `http://203.0.113.1:8000`  *(Replace `203.0.113.1` with your actual server IP address)*
-- **Observation:**  
-  - If you see the login page, the dashboard is working fine without proxy (skip to [step 4](#_4-addressing-proxy-related-issues)). 
+
+- **Step:** Open your web browser and go to: `http://203.0.113.1:8000` _(Replace `203.0.113.1` with your actual server IP address)_
+- **Observation:**
+  - If you see the login page, the dashboard is working fine without proxy (skip to [step 4](#_4-addressing-proxy-related-issues)).
   - If you don't see the login page, the issue might be with your server or coolify docker containers.
 
-
 ## 3. Check the Coolify Container
+
 If the dashboard isn’t accessible via the IP address, then follow these steps:
 
 ### A. Verify the Container Status
+
 - **Step:** SSH into your server.
 - **Command:**
-   ```bash
-   docker ps --format "table {{.Names}}\t{{.Status}}"
-- **What to Look For:**  
+  ```bash
+  docker ps --format "table {{.Names}}\t{{.Status}}"
+  ```
+- **What to Look For:**
+
   - Make sure the coolify containers are running and its status is healthy.
-  
+
     <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashbord-inaccessible/1.webp" alt="Screenshot showing Dashboard Inaccessible" />
 
 ### B. Restart the Container (if necessary)
-- **Step:** If the container appears to be running but you’re still having issues, try restarting it.
-- **Commands:**  
-    ```bash
-    docker restart NAME
-    ```
-    *(Replace `NAME` with your actual container name)*
-- **Test:** After restarting, try accessing `http://203.0.113.1:8000`  *(Replace `203.0.113.1` with your actual server IP address)* again. If this doesn't work, skip to [step 5](#_5-getting-further-assistance)
 
+- **Step:** If the container appears to be running but you’re still having issues, try restarting it.
+- **Commands:**
+  ```bash
+  docker restart NAME
+  ```
+  _(Replace `NAME` with your actual container name)_
+- **Test:** After restarting, try accessing `http://203.0.113.1:8000` _(Replace `203.0.113.1` with your actual server IP address)_ again. If this doesn't work, skip to [step 5](#_5-getting-further-assistance)
 
 ## 4. Addressing Proxy-Related Issues
+
 If the dashboard is accessible via the server IP but not through your custom domain, then follow these steps:
 
 ### A. Start the Proxy
+
 - **Step:** Go to the **Proxy** page in your Coolify dashboard.
 - **Action:** Click the **Start Proxy** button.
-  
+
     <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashbord-inaccessible/2.webp" alt="Screenshot showing Dashboard Inaccessible" />
+
 - **Wait:** Give it about two minutes, then try accessing your dashboard using your custom domain.
 
 ### B. Review Recent Changes
+
 - **Question:** Did you change any proxy configurations before the issue started?
+
   - **If Yes:** Reset the proxy configuration to its default settings and restart the proxy.
-  
+
     <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashbord-inaccessible/3.webp" alt="Screenshot showing Dashboard Inaccessible" />
+
   - **Wait:** Give it about two minutes, then try accessing your dashboard using your custom domain.
 
 ### C. Check Proxy Logs
-- **Step:** Look at the proxy logs for any error or warning messages.
-  
-    <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashbord-inaccessible/4.webp" alt="Screenshot showing Dashboard Inaccessible" />
-- **Next:** If you see errors, they may hint at what needs to be fixed (skip to next step).
 
+- **Step:** Look at the proxy logs for any error or warning messages.
+
+    <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashbord-inaccessible/4.webp" alt="Screenshot showing Dashboard Inaccessible" />
+
+- **Next:** If you see errors, they may hint at what needs to be fixed (skip to next step).
 
 ## 5. Getting Further Assistance
 
 If none of the above steps work, then follow this:
 
-- **Community Help:** Join our [Discord community ↗](https://coolify.io/discord) and create a post in the support forum channel.
+- **Community Help:** Join our [Discord community](https://coolify.io/discord) and create a post in the support forum channel.
 - **What to Share:** Include the exact error messages you’re seeing and a description of the steps you’ve already tried.
 
-
 ## Summary of Common Issues
+
 - **Proxy Not Running:** Most issues are often due to the Coolify proxy not running.
 - **Proxy Misconfiguration:** Incorrect settings in your proxy configuration can block access.
 - **Container Health:** An unhealthy Coolify container may be the problem.

--- a/docs/troubleshoot/dashboard/dashboard-slow-performance.md
+++ b/docs/troubleshoot/dashboard/dashboard-slow-performance.md
@@ -3,49 +3,54 @@ title: Slow Coolify Dashboard Performance
 description: Resolve slow Coolify dashboard loading by disabling Cloudflare Rocket Loader, checking server location, and optimizing proxy settings for faster performance.
 ---
 
-
 # Slow Coolify Dashboard Performance
+
 If your Coolify dashboard loads very slow or some pages don't load at all, this might be the guide for you.
 
-
 ## 1. Determine Your Domain Setup
-First, ask yourself: **Are you using a domain whose DNS is managed by Cloudflare?**
-- **Yes:** The issue is likely due to Cloudflare's [Rocket Loader ↗](https://developers.cloudflare.com/speed/optimization/content/rocket-loader/) feature.
-- **No:** The slowdown might be caused by your server or another factor.
 
+First, ask yourself: **Are you using a domain whose DNS is managed by Cloudflare?**
+
+- **Yes:** The issue is likely due to Cloudflare's [Rocket Loader](https://developers.cloudflare.com/speed/optimization/content/rocket-loader/) feature.
+- **No:** The slowdown might be caused by your server or another factor.
 
 ## 2. Test with Your Server's IP Address
 
 ### A. Open Your Firewall Port
+
 - **Step:** Ensure that port **8000** is open on your firewall.
 - **Why:** This lets you access the Coolify dashboard directly without proxy interference.
 
 ### B. Access the Dashboard Directly
+
 - **Step:** Open your web browser and navigate to:  
-  `http://203.0.113.1:8000` *(Replace `203.0.113.1` with your actual server IP address)*
-- **Observation:**  
-  - If the dashboard feels fast and all pages load correctly, the issue is most likely with Cloudflare [Rocket Loader ↗](https://developers.cloudflare.com/speed/optimization/content/rocket-loader/).  
+  `http://203.0.113.1:8000` _(Replace `203.0.113.1` with your actual server IP address)_
+- **Observation:**
+  - If the dashboard feels fast and all pages load correctly, the issue is most likely with Cloudflare [Rocket Loader](https://developers.cloudflare.com/speed/optimization/content/rocket-loader/).
   - If performance doesn't improve, the problem could be related to your server's location or your internet speed.
 
-
 ## 3. Addressing Cloudflare Rocket Loader
+
 If the dashboard is fast via your server IP but slow through your custom domain, try this:
-- **Step:** Log into your [Cloudflare dashboard ↗](https://dash.cloudflare.com/).
- 
+
+- **Step:** Log into your [Cloudflare dashboard](https://dash.cloudflare.com/).
+
     <ZoomableImage src="/docs/images/troubleshoot/dashboard/dashboard-slow-performance/rocket-loader.webp" alt="Rocket Loader error example" />
-- **Action:** 
+
+- **Action:**
   - Go to **Speed** on the sidebar.
   - Then navigate to **Optimization** and click on **Content Optimization**.
   - Switch the toggle for **Rocket Loader** to **Off**.
 - **Wait:** Allow a few minutes for the changes to take effect, then visit your Coolify dashboard using your domain.
 
-
 ## 4. Getting Further Assistance
+
 If none of these steps work:
-- **Community Help:** Join our [Discord community ↗](https://coolify.io/discord) and post in the support forum channel.
+
+- **Community Help:** Join our [Discord community](https://coolify.io/discord) and post in the support forum channel.
 - **What to Share:** Provide a screen recording of the issue you're experiencing and a description of the steps you’ve already tried.
 
-
 ## Summary of Common Issues
+
 - **Cloudflare Rocket Loader:** Most of the time, Rocket Loader causes issues when using a Cloudflare-managed domain
 - **Server or Internet Issues:** Unstable internet connections between the server and user can lead to performance problems.

--- a/docs/troubleshoot/dns-and-domains/lets-encrypt-not-working.md
+++ b/docs/troubleshoot/dns-and-domains/lets-encrypt-not-working.md
@@ -3,24 +3,21 @@ title: Let's Encrypt Not Generating SSL Certificates on Coolify
 description: Fix Let's Encrypt SSL failures by opening ports 80/443, checking DNS records, verifying Cloudflare settings, and troubleshooting challenges.
 ---
 
-
 # Let's Encrypt Not Generating SSL Certificates
-If you are using the default settings for the Coolify proxy and your website suddenly shows a warning about an insecure connection, it is most likely that your website is using a self-signed certificate from the Coolify proxy. This guide will help you fix the issue.
 
+If you are using the default settings for the Coolify proxy and your website suddenly shows a warning about an insecure connection, it is most likely that your website is using a self-signed certificate from the Coolify proxy. This guide will help you fix the issue.
 
 ## 1. Understand the Domain Ownership Challenges
 
-Coolify uses [Let's Encrypt ↗](https://letsencrypt.org?utm_source=coolify.io) to generate SSL certificates for your domains. 
+Coolify uses [Let's Encrypt](https://letsencrypt.org?utm_source=coolify.io) to generate SSL certificates for your domains.
 
 By default, Let's Encrypt uses the **HTTP challenge** for domain validation, but some users might use the **TLS-ALPN-01 challenge**. Here's a breakdown:
 
-- **HTTP Challenge**: 
+- **HTTP Challenge**:
   - Let's Encrypt sends an HTTP request to your server on port 80 with a unique token. If your server responds with the correct token, it confirms domain ownership, and the certificate is issued.
-  
 - **TLS-ALPN-01 Challenge**:
-  - Let's Encrypt validates your domain over port 443 (HTTPS), during the TLS handshake, Let's Encrypt expects your server to provide a special response. If the server provides the correct response, the domain is verified, and the certificate is issued. 
+  - Let's Encrypt validates your domain over port 443 (HTTPS), during the TLS handshake, Let's Encrypt expects your server to provide a special response. If the server provides the correct response, the domain is verified, and the certificate is issued.
   - If this step fails, you’ll get an SSL handshake error.
-
 
 ## 2. Check Port Accessibility
 
@@ -30,58 +27,59 @@ Ensure the appropriate ports are open for the respective challenge methods:
 
 - **For the TLS-ALPN-01 Challenge**: Port 443 (HTTPS) needs to be open and accessible from the internet. If port 443 is closed or blocked by a firewall, Let's Encrypt cannot verify your domain and generate the SSL certificate.
 
-
 ## 3. Usage of Third-Party Proxy
-If you are proxying your website through a third-party service like [Cloudflare ↗](https://www.cloudflare.com?utm_source=coolify.io), Let's Encrypt might fail to validate your domain due to the proxy interfering with the **HTTP** or **TLS-ALPN-01** challenge. In that case, you must either use a DNS challenge or stop proxying your domain through the third-party service.
 
+If you are proxying your website through a third-party service like [Cloudflare](https://www.cloudflare.com?utm_source=coolify.io), Let's Encrypt might fail to validate your domain due to the proxy interfering with the **HTTP** or **TLS-ALPN-01** challenge. In that case, you must either use a DNS challenge or stop proxying your domain through the third-party service.
 
 ## 4. Check Let's Encrypt Service Status
-Sometimes, Let's Encrypt might be having issues on their end. Check the Let's Encrypt status from [here ↗](https://letsencrypt.status.io?utm_source=coolify.io). If there is an issue, wait for them to fix it and try again once the issue is fixed.
 
+Sometimes, Let's Encrypt might be having issues on their end. Check the Let's Encrypt status from [here](https://letsencrypt.status.io?utm_source=coolify.io). If there is an issue, wait for them to fix it and try again once the issue is fixed.
 
 ## 5. Note on Certificate Validity
-Let's Encrypt certificates are valid for 90 days. If your certificate is still valid, your domain mayo work fine even if requied port 80 is closed or your domain is being proxied. This is because Coolify will continue using the existing valid certificate until it expires. 
+
+Let's Encrypt certificates are valid for 90 days. If your certificate is still valid, your domain mayo work fine even if requied port 80 is closed or your domain is being proxied. This is because Coolify will continue using the existing valid certificate until it expires.
 
 However, if your domain has been working fine over HTTPS for several months and suddenly fails to generate a new SSL certificate, it’s likely that the existing certificate has expired. At this point, Coolify won’t be able to generate a new certificate due to the issues mentioned earlier (like port 80 being closed or proxy interference).
 
-
 ## 6. Force Regenerate Certificates
-If the certificates stored on your server are corrupted or outdated, you can delete them and force Coolify generate new ones.  
-- Open your server terminal and run:  
+
+If the certificates stored on your server are corrupted or outdated, you can delete them and force Coolify generate new ones.
+
+- Open your server terminal and run:
   ```bash
   rm /data/coolify/proxy/acme.json
-  ```  
+  ```
 - Then, restart the Coolify proxy from the dashboard by clicking the Restart Proxy button.
   ::: details Guide: How to Restart Proxy from Dashboard?
 
   1. Select your server on the Coolify Dashboard
-  <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/1.webp" alt="Screenshot showing Lets Encrypt Not Working" />
+     <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/1.webp" alt="Screenshot showing Lets Encrypt Not Working" />
 
   2. Click on Restart Proxy button
-  <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/2.webp" alt="Screenshot showing Lets Encrypt Not Working" />
-  :::
-
+     <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/2.webp" alt="Screenshot showing Lets Encrypt Not Working" />
+     :::
 
 ## 7. Check Your WAF Settings
-If you are using a Web Application Firewall (WAF) like [Cloudflare WAF ↗](https://www.cloudflare.com/en-gb/application-services/products/waf/?utm_source=coolify.io), make sure it is not blocking Let's Encrypt requests.
 
+If you are using a Web Application Firewall (WAF) like [Cloudflare WAF](https://www.cloudflare.com/en-gb/application-services/products/waf/?utm_source=coolify.io), make sure it is not blocking Let's Encrypt requests.
 
 ## 8. Check Coolify Proxy logs
+
 On the Coolify proxy logs check for error messages.
 
-- If you see an error message with a 429 status code, it means that Let's Encrypt has rate-limited your server's IP address. 
+- If you see an error message with a 429 status code, it means that Let's Encrypt has rate-limited your server's IP address.
+
   - In this case, wait for a while and check your domain again. Most users won't encounter this, but it can happen if you are using a shared IP address.
 
-- If you see an error message with a 403 status code, it means that requests from Let's Encrypt are blocked by something like a Web Application Firewall (WAF). 
+- If you see an error message with a 403 status code, it means that requests from Let's Encrypt are blocked by something like a Web Application Firewall (WAF).
   ::: details Guide: How to check Coolify proxy logs?
 
   1. Select your server on the Coolify Dashboard
-  <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/1.webp" alt="Screenshot showing Lets Encrypt Not Working" />
+     <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/1.webp" alt="Screenshot showing Lets Encrypt Not Working" />
 
   2. Go to the proxy section and click the refresh button
-  <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/3.webp" alt="Screenshot showing Lets Encrypt Not Working" />
-  :::
-
+     <ZoomableImage src="/docs/images/troubleshoot/dns-and-domains/lets-encrypt-not-working/3.webp" alt="Screenshot showing Lets Encrypt Not Working" />
+     :::
 
 ## 9. Verify DNS Records
 
@@ -96,11 +94,14 @@ If either the **IPv4** or **IPv6** address is misconfigured, the challenge may f
 - If your domain resolves to both **IPv4** and **IPv6**, but the **IPv6 (AAAA) record** has **port 80 closed**, the HTTP challenge will fail. Similarly, if **port 443** is closed for IPv6, the TLS-ALPN challenge will fail, even if **IPv4** passes the challenge.
 
 To ensure successful validation:
+
 - Both **IPv4 (A record)** and **IPv6 (AAAA record)** must be able to serve the challenge file correctly.
 
 If you don’t need IPv6, you can remove the **AAAA record** from your DNS configuration. This will make Let's Encrypt use **IPv4** for the challenge.
 
 ## Support
+
 If none of the above steps work, try these additional options:
-- **Community Help:** Join our [Discord community ↗](https://coolify.io/discord) and post in the support forum channel.
+
+- **Community Help:** Join our [Discord community](https://coolify.io/discord) and post in the support forum channel.
 - **What to Share:** Include a description of your issue, any error messages, and the steps you have already tried.

--- a/docs/troubleshoot/dns-and-domains/wildcard-ssl-certs.md
+++ b/docs/troubleshoot/dns-and-domains/wildcard-ssl-certs.md
@@ -4,43 +4,45 @@ description: Fix wildcard SSL certificate issues in Coolify by verifying install
 ---
 
 # Coolify not using Wildcard SSL Certificates
+
 If your wildcard SSL certificate isn't working with your domain, it may be due to configuration problems. Here's how you can check and fix it.
 
-
 ## 1. Check the SSL Certificate Validity
-- **Verify the Certificate:** Make sure the SSL certificate is valid for the domain.  
+
+- **Verify the Certificate:** Make sure the SSL certificate is valid for the domain.
   - Confirm the Common Name (CN) matches your domain.
   - Double-check that your wildcard certificate is not expired.
 
-
 ## 2. Verify Certificate Installation
-- **File Extensions:** Make sure the SSL certificate file ends with `.cert` and the key file ends with `.key`.  
-  - Some providers give files in `.pem` format, which must be converted to `.cert` and `.key` before adding them to your server (simply rename the files to `.cert` for the certificate and `.key` for the key)
-- **File Location:**  Make sure your `.cert` and `.key` files are located in the `/data/coolify/proxy/certs` directory.
 
+- **File Extensions:** Make sure the SSL certificate file ends with `.cert` and the key file ends with `.key`.
+  - Some providers give files in `.pem` format, which must be converted to `.cert` and `.key` before adding them to your server (simply rename the files to `.cert` for the certificate and `.key` for the key)
+- **File Location:** Make sure your `.cert` and `.key` files are located in the `/data/coolify/proxy/certs` directory.
 
 ## 3. Check the Coolify Proxy Configuration
-- **Add Certificate in Dashboard:** Make sure you have added the SSL certificate configuration in the Coolify proxy via the dashboard. More details can be found [here](/knowledge-base/proxy/traefik/custom-ssl-certs).
-- **Check File Mounts:** If you have modified the proxy configuration, verify that the `/data/coolify/proxy` directory is mounted correctly. 
 
+- **Add Certificate in Dashboard:** Make sure you have added the SSL certificate configuration in the Coolify proxy via the dashboard. More details can be found [here](/knowledge-base/proxy/traefik/custom-ssl-certs).
+- **Check File Mounts:** If you have modified the proxy configuration, verify that the `/data/coolify/proxy` directory is mounted correctly.
 
 ## 4. Remove Old Certificates
-- **Old Certificate Issue:**  The Coolify proxy may be using an old certificate stored in the `acme.json` file.
-- **Action:**  Delete the `acme.json` file from the `/data/coolify/proxy` directory and restart the Coolify proxy from the dashboard by clicking the restart proxy button.
 
+- **Old Certificate Issue:** The Coolify proxy may be using an old certificate stored in the `acme.json` file.
+- **Action:** Delete the `acme.json` file from the `/data/coolify/proxy` directory and restart the Coolify proxy from the dashboard by clicking the restart proxy button.
 
 ## 5. Clear Your Browser Cache
-- **Cache Issue:** Your browser might be caching an old SSL certificate.
-- **Action:**  Check your website using a different browser or network.  
-  - You can also use sandbox tools like [Browserling ↗](https://www.browserling.com?utm_source=coolify.io) to test your site.
 
-     
+- **Cache Issue:** Your browser might be caching an old SSL certificate.
+- **Action:** Check your website using a different browser or network.
+  - You can also use sandbox tools like [Browserling](https://www.browserling.com?utm_source=coolify.io) to test your site.
+
 ## 6. Verify DNS Challenge Configuration
+
 - **DNS Challenge Check:** If you are using a DNS challenge, confirm that it is set up correctly.
 - **Action:** Verify that you have selected the correct DNS provider, API Keys and check the challenge settings are properly configured.
 
-
 ## Support
+
 If none of the above steps work, try these additional options:
-- **Community Help:** Join our [Discord community ↗](https://coolify.io/discord) and post in the support forum channel.
+
+- **Community Help:** Join our [Discord community](https://coolify.io/discord) and post in the support forum channel.
 - **What to Share:** Include a description of your issue, screenshots of your configuration, any error messages, and the steps you have already tried.

--- a/docs/troubleshoot/overview.md
+++ b/docs/troubleshoot/overview.md
@@ -10,7 +10,7 @@ This section provides solutions for resolving issues you might encounter with Co
 Check the sidebar for a list of all available trouble shooting guides.
 
 ::: warning Note:
-  **Please note that this troubleshooting guide is still being actively developed.**
+**Please note that this troubleshooting guide is still being actively developed.**
 :::
 
-If you have a suggestion for a new troubleshooting guide or want to contribute, feel free to submit a pull request or open an issue with a detailed description in our GitHub [docs repository ↗](https://github.com/coollabsio/documentation-coolify/issues).
+If you have a suggestion for a new troubleshooting guide or want to contribute, feel free to submit a pull request or open an issue with a detailed description in our GitHub [docs repository](https://github.com/coollabsio/documentation-coolify/issues).

--- a/docs/troubleshoot/server/crash-during-build.md
+++ b/docs/troubleshoot/server/crash-during-build.md
@@ -3,56 +3,63 @@ title: Server Crash During Build
 description: Fix server crashes during Coolify builds by offloading to external build servers, using GitHub Actions, or upgrading server resources for Docker image builds.
 ---
 
-
 # Server Unresponsive or crashes during Build
+
 Coolify supports two deployment methods: deploying with a **pre-built** Docker image and building from **source**. Knowing which method you're using can help you fix performance problems better.
 
 ## 1. Understanding Your Deployment Method
+
 ### A. Pre-built Docker Image Deployment
+
 - Coolify starts a new container from an existing Docker image that you or someone else have already built.
 
 ### B. Building from Source Deployment
+
 - Coolify builds a Docker image on your server using your application’s source code, and then starts a container from this newly created docker image.
 
-
 ## 2. Troubleshooting Performance Issues
+
 If your server becomes very slow or crashes during deployment, consider the following steps based on your deployment method:
 
-- **For Pre-built Image Deployments:**  
-    - Since the container is started directly from the docker image, high resource usage is most likely due to the running application.  
-    - **Solution:** Consider upgrading your server to better accommodate the application’s resource needs.
+- **For Pre-built Image Deployments:**
 
-- **For Building from Source Deployments:**  
+  - Since the container is started directly from the docker image, high resource usage is most likely due to the running application.
+  - **Solution:** Consider upgrading your server to better accommodate the application’s resource needs.
+
+- **For Building from Source Deployments:**
+
   - The docker image build process can overload your server.
-  - **Solution:**  Offload the build process to an external [Build Server](/knowledge-base/server/build-server), or use an alternative method such as [GitHub Actions](https://docs.github.com/en/actions) to handle the build externally.  Alternatively, consider upgrading your server’s capacity.
+  - **Solution:** Offload the build process to an external [Build Server](/knowledge-base/server/build-server), or use an alternative method such as [GitHub Actions](https://docs.github.com/en/actions) to handle the build externally. Alternatively, consider upgrading your server’s capacity.
 
 - **General Tip:**  
   SSH into your server and run `htop` to monitor processes. Identify any process consuming excessive resources, and kill it if necessary.
 
-
 ## 3. Offloading Builds with GitHub Actions
+
 To reduce the load on your server during deployments, follow this process:
-- **Process:**  
+
+- **Process:**
   - Use [GitHub Actions](https://docs.github.com/en/actions) to build your Docker image externally.
   - Push the built image to a container registry (e.g., [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)).
   - Once the build is complete, configure coolify to deploy the new version automatically.
-  
 - **Benefit:** This method minimizes the workload on your server, resulting in smoother deployments.
 
 - **Learn More:** [View our GitHub Actions workflow file](https://github.com/coollabsio/documentation-coolify/blob/main/.github/workflows/production-build.yml).
 
-
 ## Summary
-- **Deployment Methods:**  
-  - **Pre-built Image:** Directly starts a container from an existing image.  
+
+- **Deployment Methods:**
+  - **Pre-built Image:** Directly starts a container from an existing image.
   - **Building from Source:** Builds an image on your server before starting a container.
-- **Troubleshooting:**  
+- **Troubleshooting:**
   - Identify if the issue is due to the application’s resource needs or the image build process.
   - Upgrade your server or offload builds as needed.
-- **Optimization:**  
+- **Optimization:**
   - Using GitHub Actions to build Docker images externally can significantly reduce local resource usage.
 
 ## Support
+
 If none of the above steps work, then follow this:
-- **Community Help:** Join our [Discord community ↗](https://coolify.io/discord) and create a post in the support forum channel.
+
+- **Community Help:** Join our [Discord community](https://coolify.io/discord) and create a post in the support forum channel.
 - **What to Share:** The issue you are facing, your server specifications (e.g., operating system, CPU, RAM), and a description of the steps you’ve already tried.


### PR DESCRIPTION
## Summary

- Enable VitePress's built-in `externalLinkIcon` feature to automatically display icons on external links
- Remove manual "↗" symbols from markdown files (no longer needed with automatic icons)

## Changes

### Configuration
- Added `externalLinkIcon: true` to VitePress theme config in `docs/.vitepress/config.mts`

### Content Cleanup
- Removed manual "↗" symbols from 206 markdown files across the documentation
- Cleaned up inline link decorations to rely on automatic icon generation

## Benefits

- **Automated**: No need to manually add external link indicators to every external link
- **Consistent**: All external links automatically get the same treatment across the entire documentation
- **Professional**: Uses VitePress's built-in SVG icon which scales properly and respects theme colors
- **Maintainable**: Contributors no longer need to remember to add manual symbols to external links
- **Cleaner Markdown**: Link text remains semantic without visual decoration symbols

## Implementation Details

VitePress automatically adds a small SVG arrow icon to all external links (URLs containing `://` or with `target="_blank"`). The feature automatically excludes:
- Links with the `.no-icon` class
- SVG links
- Links containing images

## Test Plan

- [ ] Verify external links display icon correctly
- [ ] Test in both light and dark modes  
- [ ] Verify internal links are not affected
- [ ] Test across different documentation sections (builds, services, knowledge base, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)