### PR TITLE
feat: add dynamic Open Graph tags from frontmatter

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,19 +42,49 @@ export default defineConfig({
     ]
   },
 
+  transformPageData(pageData) {
+    const baseUrl = env.VITE_SITE_URL ?? 'https://coolify.io/docs/'
+    const defaultImage = 'https://coolcdn.b-cdn.net/assets/coolify/og-image-docs.png'
+    const defaultDescription = 'Self hosting with superpowers: An open-source & self-hostable Heroku / Netlify / Vercel alternative.'
+
+    // Build canonical URL for this page
+    const pageUrl = `${baseUrl}${pageData.relativePath.replace(/((^|\/)index)?\.md$/, '$2')}`
+
+    // Extract values with fallback chain
+    const title = pageData.frontmatter.title || pageData.title || 'Coolify Docs'
+    const description = pageData.frontmatter.description || defaultDescription
+
+    // Handle image with relative to absolute URL conversion
+    const relativeImage = pageData.frontmatter.image
+    const image = relativeImage
+      ? `${baseUrl.replace(/\/$/, '')}${relativeImage.startsWith('/') ? relativeImage : '/' + relativeImage}`.replace(/\/docs\/docs\//, '/docs/')
+      : defaultImage
+
+    // Initialize head array if it doesn't exist
+    pageData.frontmatter.head ??= []
+
+    // Add Open Graph tags
+    pageData.frontmatter.head.push(
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: description }],
+      ['meta', { property: 'og:url', content: pageUrl }],
+      ['meta', { property: 'og:image', content: image }]
+    )
+
+    // Add Twitter Card tags
+    pageData.frontmatter.head.push(
+      ['meta', { property: 'twitter:title', content: title }],
+      ['meta', { property: 'twitter:description', content: description }],
+      ['meta', { property: 'twitter:url', content: pageUrl }],
+      ['meta', { property: 'twitter:image', content: image }]
+    )
+  },
+
   head: [
     ['meta', { name: 'theme-color', content: '#000000' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:title', content: 'Coolify Docs' }],
-    ['meta', { property: 'og:url', content: env.VITE_SITE_URL ?? 'https://coolify.io/docs/' }],
-    ['meta', { property: 'og:description', content: 'Self hosting with superpowers: An open-source & self-hostable Heroku / Netlify / Vercel alternative.' }],
-    ['meta', { property: 'og:image', content: 'https://coolcdn.b-cdn.net/assets/coolify/og-image-docs.png' }],
     ['meta', { property: 'twitter:site', content: '@coolifyio' }],
     ['meta', { property: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { property: 'twitter:title', content: 'Coolify Docs' }],
-    ['meta', { property: 'twitter:description', content: 'Self hosting with superpowers: An open-source & self-hostable Heroku / Netlify / Vercel alternative.' }],
-    ['meta', { property: 'twitter:url', content: env.VITE_SITE_URL ?? 'https://coolify.io/docs/' }],
-    ['meta', { property: 'twitter:image', content: 'https://coolcdn.b-cdn.net/assets/coolify/og-image-docs.png' }],
     ['link', { rel: 'icon', href: '/docs/coolify-logo-transparent.png', alt: "Coolify's Logo" }],
     ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
     ['script', { defer: 'true', src: 'https://analytics.coollabs.io/js/script.tagged-events.js', 'data-domain': env.VITE_ANALYTICS_DOMAIN ?? 'coolify.io/docs' }],


### PR DESCRIPTION
## Summary

Implements dynamic Open Graph and Twitter Card meta tags using VitePress's `transformPageData` hook. Each documentation page now generates custom social media previews based on its frontmatter metadata.

## Changes

### Added
- **`transformPageData` hook** in `config.mts` that:
  - Extracts `title`, `description`, and optional `image` from page frontmatter
  - Converts relative image paths to absolute URLs (required by Open Graph spec)
  - Dynamically injects Open Graph and Twitter Card meta tags per-page
  - Implements comprehensive fallback chain for missing values

### Removed
- Static duplicate Open Graph tags from global `head` array:
  - `og:title`, `og:description`, `og:url`, `og:image`
  - `twitter:title`, `twitter:description`, `twitter:url`, `twitter:image`
- Kept static tags: `og:type`, `twitter:site`, `twitter:card`

## Features

✅ **Rich Social Media Previews** - Unique titles/descriptions for Twitter, Discord, LinkedIn, Slack  
✅ **Optional Custom Images** - Add `image` field to frontmatter for page-specific preview images  
✅ **Backward Compatible** - All existing pages work without modification (uses fallbacks)  
✅ **SEO Improvement** - Each page gets unique, descriptive meta tags  

## Usage Examples

### Basic (works with existing frontmatter)
```yaml
---
title: "Pterodactyl Panel"
description: "Host game servers on Coolify with Pterodactyl panel..."
---
```
**Result:** Social preview shows "Pterodactyl Panel" with custom description

### With Custom Image (optional enhancement)
```yaml
---
title: "Pterodactyl Panel"
description: "Host game servers..."
image: /docs/images/services/pterodactyl_logo_transparent.png
---
```
**Result:** Social preview shows the logo image instead of default OG image

## Fallback Logic

- **Title**: `frontmatter.title` → `pageData.title` → `'Coolify Docs'`
- **Description**: `frontmatter.description` → site description
- **Image**: `frontmatter.image` → default OG image (`https://coolcdn.b-cdn.net/assets/coolify/og-image-docs.png`)

## Testing

Tested with VitePress build system. The `transformPageData` hook runs during SSG and correctly:
- Generates unique meta tags for each page
- Handles missing frontmatter gracefully
- Converts relative paths to absolute URLs
- Maintains backward compatibility

## Related Issues

-

🤖 Generated with [Claude Code](https://claude.com/claude-code)