### PR TITLE
fix: Include git history in Docker build for lastUpdated timestamps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ COPY tailwind.config.js .
 COPY env.d.ts .
 COPY tsconfig*.json ./
 
+# Copy git history for lastUpdated timestamps
+COPY .git/ ./.git/
+
 # Build with cache
 RUN --mount=type=cache,target=/root/.bun \
     --mount=type=cache,target=/root/.cache/bun \


### PR DESCRIPTION
## Summary

Fixes #255 - Last modified date not showing in production

This PR adds the `.git` directory to the Docker build context, enabling VitePress's `lastUpdated` feature to work in production builds.

## Problem

VitePress's `lastUpdated` feature (enabled in [config.mts:32](https://github.com/coollabsio/coolify-docs/blob/main/docs/.vitepress/config.mts#L32)) requires access to git history to display "Last modified" timestamps on documentation pages. Previously:

- ✅ **Development**: Worked correctly (git history available)
- ❌ **Production**: Timestamps missing (git history not in Docker build context)

## Solution

Added `COPY .git/ ./.git/` to the Dockerfile before the build step.

## Analysis

The cache-busting impact of this change is minimal:
- ~85% of commits already modify `docs/` content, which busts the cache anyway
- Only ~15% of commits are non-docs changes (workflows, configs, etc.)
- For a docs repository, the practical overhead is acceptable

## Trade-offs Considered

We evaluated several alternatives:

| Approach | Pros | Cons | Decision |
|----------|------|------|----------|
| **Copy full `.git`** (this PR) | Simple, accurate timestamps, 1 line | +122MB to build context, cache busts on every commit | ✅ **Selected** - pragmatic for docs repo |
| Shallow git init | Minimal overhead | All files show same timestamp (build time) | ❌ Loses accuracy |
| Build-time timestamp extraction | Perfect caching | Requires custom VitePress plugin | ❌ Over-engineered |
| Layer reordering | Better cache layering | Still busts on every commit | ❌ Doesn't solve root cause |

## Testing

- [ ] Verify timestamps appear in production after merge
- [ ] Confirm build completes successfully
- [ ] Check multi-arch builds work (amd64 + arm64)

## Impact

- **Build context size**: +122MB (build stage only, not in final nginx image)
- **Cache invalidation**: ~15% additional misses for non-docs commits
- **User benefit**: 791 markdown files now show accurate last updated timestamps

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>