### PR TITLE
docs: S3 compatible storage provider - CloudPe

### DIFF
--- a/docs/knowledge-base/s3/introduction.md
+++ b/docs/knowledge-base/s3/introduction.md
@@ -15,6 +15,7 @@ Currently supported S3 compatible storages are:
 - Hetzner S3 Storage (beta)
 - Wasabi hot cloud storage
 - Vultr
+- CloudPe Object Storage
 
 Other's could work, but not tested yet. If you test it, please let us know.
 


### PR DESCRIPTION
Hi, I'm using **CloudPe Object storage** for s3 backups and it seems to work well. Hence I'd like to add this as a compatible provider. 

Adding link to their docs for configuring/using the s3 bucket for reference:
https://www.cloudpe.com/knowledge-base/create-manage-bucket-on-object-storage/
https://www.cloudpe.com/knowledge-base/accessing-cloudpe-s3-buckets-using-s3cmd/

If you need me to run some tests for this, let me know!