### PR TITLE
docs: Add custom Docker entrypoint documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ COPY tailwind.config.js .
 COPY env.d.ts .
 COPY tsconfig*.json ./
 
+# Copy git history for lastUpdated timestamps
+COPY .git/ ./.git/
+
 # Build with cache
 RUN --mount=type=cache,target=/root/.bun \
     --mount=type=cache,target=/root/.cache/bun \

--- a/docs/knowledge-base/docker/custom-commands.md
+++ b/docs/knowledge-base/docker/custom-commands.md
@@ -1,6 +1,6 @@
 ---
 title: "Custom Commands"
-description: "Add custom Docker run options to Coolify deployments including GPU support, security options, system controls, devices, and resource limits."
+description: "Add custom Docker run options to Coolify deployments including custom entrypoints, GPU support, security options, system controls, devices, and resource limits."
 ---
 
 # Custom Commands
@@ -25,9 +25,69 @@ For deploying your resources, you can add custom options to the final docker com
 - `--ulimit`
 - `--privileged`
 - `--gpus`
+- `--entrypoint`
 
 ## Usage
 
 You can simply add the options to the `Custom Docker Options` field on the `General` tab of your resource.
 
 Example: `--cap-add SYS_ADMIN --privileged`
+
+## Custom Entrypoint
+
+The `--entrypoint` option allows you to override the default entrypoint of a Docker image without building a custom image.
+
+### Syntax
+
+Coolify supports three entrypoint syntax variations:
+
+1. **Simple entrypoint**:
+   ```bash
+   --entrypoint /bin/sh
+   ```
+
+2. **Quoted command with arguments**:
+   ```bash
+   --entrypoint "sh -c 'npm start'"
+   ```
+
+3. **Assignment syntax**:
+   ```bash
+   --entrypoint=/usr/local/bin/custom-script
+   ```
+
+### Use Cases
+
+#### Multiple Service Types from Single Image
+
+Some Docker images, like ServerSideUp PHP, provide multiple entrypoints for different service types:
+- Worker processes
+- Queue schedulers
+- Background jobs
+- Web servers
+
+Example for running a Laravel Horizon worker:
+```bash
+--entrypoint php --entrypoint artisan --entrypoint horizon
+```
+
+#### Custom Initialization Scripts
+
+Override the default entrypoint to run custom initialization:
+```bash
+--entrypoint "/app/custom-init.sh"
+```
+
+### Usage in Coolify
+
+1. Navigate to your resource's **General** tab
+2. Locate the **Custom Docker Options** field
+3. Add your entrypoint option along with any other custom options:
+   ```bash
+   --entrypoint /bin/sh --cap-add SYS_ADMIN
+   ```
+4. Save and redeploy your application
+
+::: info Note
+The entrypoint option is converted to Docker Compose format during deployment, supporting both Dockerfile and Docker Compose build packs.
+:::


### PR DESCRIPTION
Documents the new `--entrypoint` custom Docker option added in PR #7097. Includes all three supported syntax variations, real-world use cases for multi-entrypoint images like ServerSideUp PHP, and clear step-by-step usage instructions for Coolify users.