### PR TITLE
docs: Add Advanced menu location for build argument settings

### DIFF
--- a/docs/applications/build-packs/docker-compose.md
+++ b/docs/applications/build-packs/docker-compose.md
@@ -152,18 +152,18 @@ labels:
 
 ### Build Arguments
 
-When building images with Docker Compose, Coolify can inject build arguments into your build process.
+When building images with Docker Compose, Coolify can inject build arguments into your build process. You can configure these settings in the **Advanced** menu of your application.
 
 #### Inject Build Args to Dockerfile
 
-Controls whether Coolify automatically injects build arguments during the build. Disable this if you want full control over build arguments in your Dockerfile.
+Controls whether Coolify automatically injects build arguments during the build. Disable this in the Advanced menu if you want full control over build arguments in your Dockerfile.
 
 - **Enabled (default):** Coolify automatically injects build arguments
 - **Disabled:** You manage `ARG` statements yourself in the Dockerfile
 
 #### Include Source Commit in Build
 
-Controls whether the `SOURCE_COMMIT` variable (Git commit hash) is included in builds. Disabled by default to preserve Docker's build cache between commits.
+Controls whether the `SOURCE_COMMIT` variable (Git commit hash) is included in builds. Disabled by default to preserve Docker's build cache between commits. You can enable this in the Advanced menu if your build process requires the commit hash.
 
 - **Disabled (default):** `SOURCE_COMMIT` is not included, improving cache utilization
 - **Enabled:** `SOURCE_COMMIT` is included as a build argument

--- a/docs/applications/build-packs/dockerfile.md
+++ b/docs/applications/build-packs/dockerfile.md
@@ -77,16 +77,18 @@ Click on the **Environment Variables** tab to add or update them.
 
 Coolify automatically injects build arguments into your Dockerfile during the build process. These include environment variables you've configured and predefined system values like `SOURCE_COMMIT`.
 
+You can configure these settings in the **Advanced** menu of your application.
+
 #### Inject Build Args to Dockerfile
 
-By default, Coolify injects Docker build arguments (`ARG` statements) into your Dockerfile. If you prefer to manage build arguments manually in your Dockerfile, you can disable this behavior.
+By default, Coolify injects Docker build arguments (`ARG` statements) into your Dockerfile. If you prefer to manage build arguments manually in your Dockerfile, you can disable this behavior in the Advanced menu.
 
 - **Enabled (default):** Coolify automatically injects build arguments
 - **Disabled:** You manage `ARG` statements yourself in the Dockerfile
 
 #### Include Source Commit in Build
 
-The `SOURCE_COMMIT` variable contains the Git commit hash of your source code. By default, this is excluded from the build to preserve Docker's build cache.
+The `SOURCE_COMMIT` variable contains the Git commit hash of your source code. By default, this is excluded from the build to preserve Docker's build cache. You can enable this in the Advanced menu if needed.
 
 - **Disabled (default):** `SOURCE_COMMIT` is not included, improving cache utilization
 - **Enabled:** `SOURCE_COMMIT` is included as a build argument


### PR DESCRIPTION
## Summary
- Added documentation clarifying that build argument settings can be configured in the Advanced menu
- Updated both Dockerfile and Docker Compose build pack documentation

## Changes
This PR adds explicit mentions that the following settings are located in the **Advanced** menu:
- **Inject Build Args to Dockerfile**: Control automatic injection of build arguments
- **Include Source Commit in Build**: Control inclusion of `SOURCE_COMMIT` in builds

## Related
This is a follow-up to the documentation added for PR #7352 features, making it clearer where users can find these settings in the UI.

## Test plan
- [x] Documentation builds successfully
- [x] Changes are clear and accurate
- [x] Consistent across both Dockerfile and Docker Compose pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)