### PR TITLE
docs: Remove demo link from filebrowser.md

### DIFF
--- a/docs/services/filebrowser.md
+++ b/docs/services/filebrowser.md
@@ -20,12 +20,6 @@ Filebrowser provides a file managing interface within a specified directory and 
 
 ![gif](https://user-images.githubusercontent.com/5447088/50716739-ebd26700-107a-11e9-9817-14230c53efd2.gif)
 
-## Demo
-
-Link: [Filebrowser Demo](https://demo.filebrowser.org/?utm_source=coolify.io)
-
-Credentials: demo/demo
-
 ## Links
 
 - [The official Filebrowser website](https://filebrowser.org?utm_source=coolify.io)


### PR DESCRIPTION
Removed unreachable demo link info from Filebrowser service.