### PR TITLE
fix(docs): correct Firefly III service link path

### DIFF
--- a/docs/services/all.md
+++ b/docs/services/all.md
@@ -224,7 +224,7 @@ Complete directory of all one-click services available in Coolify, organized by 
 
 - [Actual Budget](/services/actualbudget) - A local-first personal finance tool based on zero-based budgeting
 - [BudgE](/services/budge) - A budgeting personal finance app
-- [Firefly III](/services/firefly-iii) - A personal finances manager
+- [Firefly III](/services/firefly) - A personal finances manager
 - [Maybe](/services/maybe) - Personal finance and wealth management application
 
 ## Forum


### PR DESCRIPTION
This PR fixes a broken link regarding the Firefly III service.

The link was pointing to `/services/firefly-iii`, but the correct path based on the file structure is `/services/firefly`.

**Changes:**
- Updated Firefly III link to point to the correct documentation page.