### PR TITLE
docs: update IPv6 port guideline

### DIFF
--- a/docs/troubleshoot/server/connection-issues.md
+++ b/docs/troubleshoot/server/connection-issues.md
@@ -29,6 +29,6 @@ If you're experiencing unstable connections, most of the times (90% of the cases
 In case of Coolify Cloud, you can enable connection from Coolify Cloud IP addresses by adding the following to the UFW rules:
 ```sh
  ufw insert 1 allow from <ipv4>/22 to any port 22
- ufw insert 2 allow from <ipv6>/22 to any port 22
+ ufw insert 2 allow from <ipv6>/64 to any port 64
 ```
 > You can find the IP addresses in the Coolify Cloud here: https://coolify.io/ipv4.txt and https://coolify.io/ipv6.txt


### PR DESCRIPTION
The linked ipv6 addresses include a port number in them where as the linked ipv4 addresses do not. 

Users following this guide will encounter the following error: ` ERROR: Bad source address`  if current guidance is followed via using the following:  `ufw insert 2 allow from 2a01:4f8:c17:ed5b::/64/22 to any port 22` . Due to there being multiple ports.

Potential options to consider:

1. Remove the port from the ipv6 section here. 
2. Amend the port here to be what is in the text file (matching the ipv4 guidelines) and removing the port from the text file
3. Other? - Open to better ideas ofc.