### PR TITLE
docs: Coolify Add instruction to disable gzip compression

### DIFF
--- a/docs/services/beszel.md
+++ b/docs/services/beszel.md
@@ -15,6 +15,7 @@ Lightweight server monitoring hub with historical data, docker stats, and alerts
 - In the UI, `Add a new System`
 - Enter `beszel-agent` in Host/IP
 - Copy the public Key to `KEY` env variable and token to `TOKEN` variable in Beszel's project environment variables (These are obtained from Beszel UI when adding a new system)
+- Disable the gzip compression in the hub service settings.
 
 ## Links
 


### PR DESCRIPTION
Added instruction to disable gzip compression in hub service settings. 

Mentioned by creator: https://www.beszel.dev/guide/common-issues#real-time-stats-not-working-changes-not-saving