### PR TITLE
fix: wrong link for docker compose in shared variables

### DIFF
--- a/docs/knowledge-base/environment-variables.md
+++ b/docs/knowledge-base/environment-variables.md
@@ -39,7 +39,7 @@ You can set them on the `Environments` page (select a `Project`), under the gear
 
 ### Using Environment and Shared Variables in Docker Compose
 
-Within Coolify you can configure these easily following the details found in the [Knowledge Base for Docker Compose](/knowledge-base/compose#defining-environment-and-shared-variables).
+Within Coolify you can configure these easily following the details found in the [Knowledge Base for Docker Compose](/knowledge-base/docker/compose#shared-environment-variables).
 
 ## Predefined Variables
 


### PR DESCRIPTION
Small fix: in [Using Environment and Shared Variables in Docker Compose](https://coolify.io/docs/knowledge-base/environment-variables#using-environment-and-shared-variables-in-docker-compose), the link for `Knowledge Base for Docker Compose` was wrong. Updated it to what I believe is correct.