### PR TITLE
[docs] fixed broken links on cloudflare integrations overview

### DIFF
--- a/docs/integrations/cloudflare/tunnels/all-resource.md
+++ b/docs/integrations/cloudflare/tunnels/all-resource.md
@@ -26,7 +26,7 @@ To follow this guide, you'll need:
 ## Before We Start
 
 - We assume you have Coolify running on your server.
-- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
+- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/integrations/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
 
 ## How It Works?
 
@@ -149,7 +149,7 @@ Enter the domain you want to use for your resource/app and deploy your resource.
 ::: warning HEADS UP!  
  You should enter the domain as **HTTP** because Cloudflare handles **HTTPS** and TLS terminations. If you use **HTTPS** for your resource, you may encounter a **TOO_MANY_REDIRECTS** error.
 
-If your app requires **HTTPS** for features like cookies or login, follow the [Full TLS HTTPS Guide](/knowledge-base/cloudflare/tunnels/full-tls) after completing this guide.  
+If your app requires **HTTPS** for features like cookies or login, follow the [Full TLS HTTPS Guide](/integrations/cloudflare/tunnels/full-tls) after completing this guide.  
 :::
 
 **Congratulations**! You've successfully set up a resource that can be accessed by anyone on the internet your domain.

--- a/docs/integrations/cloudflare/tunnels/full-tls.md
+++ b/docs/integrations/cloudflare/tunnels/full-tls.md
@@ -15,7 +15,7 @@ This guide solves that issue by configuring your resources to run fully on HTTPS
 
 This guide is ideal for users who:
 
-- Have followed our [Tunnel All Resources Using Cloudflare Tunnel](/knowledge-base/cloudflare/tunnels/all-resource) or [Tunnel Specific Resources Using Cloudflare Tunnel](/knowledge-base/cloudflare/tunnels/single-resource) guide.
+- Have followed our [Tunnel All Resources Using Cloudflare Tunnel](/integrations/cloudflare/tunnels/all-resource) or [Tunnel Specific Resources Using Cloudflare Tunnel](/integrations/cloudflare/tunnels/single-resource) guide.
 - Need their resources deployed with Coolify to run on HTTPS for applications requiring HTTPS for JWT issuance, callback functions, or similar features.
 
 ## Setup Requirements
@@ -94,12 +94,15 @@ Your certificate will now be generated.
 Next, you'll add these to your server running Coolify and configure Coolify to use this certificate.
 
 ## 2. Add Origin Certificate to Your Server
+
 SSH into your server or use Coolify's terminal feature. For this guide, I’m using SSH:
+
 ```sh
 ssh shadowarcanist@203.0.113.1
 ```
 
 Once logged in, navigate to the Coolify proxy directory:
+
 ```sh
 $ cd /data/coolify/proxy
 ```
@@ -110,90 +113,108 @@ Adding certificates slightly varies for Caddy and Traefik proxy so choose the co
 
 == Traefik
 Create the `certs` directory:
+
 ```sh
 $ mkdir certs
 ```
 
 Verify it was created:
+
 ```sh
 $ ls
 > acme.json  certs docker-compose.yml  dynamic
 ```
 
 Now, navigate into the **certs** directory:
+
 ```sh
 $ cd certs
 ```
 
 Create two new files for the certificate and private key:
+
 ```sh
 $ touch shadowarcanist.cert shadowarcanist.key
 ```
 
 Verify the files were created:
+
 ```sh
 $ ls
 > shadowarcanist.cert shadowarcanist.key
 ```
 
 Open the **shadowarcanist.cert** file and paste the certificate from the Cloudflare dashboard:
+
 ```sh
-$ nano shadowarcanist.cert 
+$ nano shadowarcanist.cert
 ```
+
 Save and exit after pasting the certificate.
 
 Do the same for the **shadowarcanist.key** file and paste the private key:
+
 ```sh
-$ nano shadowarcanist.key 
+$ nano shadowarcanist.key
 ```
+
 Save and exit.
 
 == Caddy
 Create the `caddy/data/certs` directory:
+
 ```sh
 $ mkdir -p caddy/data/certs
 ```
 
 Verify it was created:
+
 ```sh
 $ ls caddy/data
 > certs
 ```
 
 Now, navigate into the **certs** directory:
+
 ```sh
 $ cd caddy/data/certs
 ```
 
 Create two new files for the certificate and private key:
+
 ```sh
 $ touch shadowarcanist.cert shadowarcanist.key
 ```
 
 Verify the files were created:
+
 ```sh
 $ ls
 > shadowarcanist.cert shadowarcanist.key
 ```
 
 Open the **shadowarcanist.cert** file and paste the certificate from the Cloudflare dashboard:
+
 ```sh
-$ nano shadowarcanist.cert 
+$ nano shadowarcanist.cert
 ```
+
 Save and exit after pasting the certificate.
 
 Do the same for the **shadowarcanist.key** file and paste the private key:
+
 ```sh
-$ nano shadowarcanist.key 
+$ nano shadowarcanist.key
 ```
+
 Save and exit.
 
 :::
 
 Now the origin certificate is installed on your server.
 
-
 ## 3. Configure Coolify to Use the Origin Certificate
+
 <ZoomableImage src="/docs/images/integrations/cloudflare/tunnels/full-tls/14.webp" />
 
 1. Go to the **Server** section in the sidebar.
@@ -213,6 +234,7 @@ Adding Dynamic Configuration slightly varies for Caddy and Traefik proxy so choo
 
 1. Choose a name for your configuration (must end with `.yaml`).
 2. Enter the following details in the configuration field:
+
 ```sh
 tls:
   certificates:
@@ -222,8 +244,11 @@ tls:
 ```
 
 3. Save the configuration
+
 ---
+
 If you want to add multiple certificates and keys, you can do it like this:
+
 ```sh
 tls:
   certificates:
@@ -243,6 +268,7 @@ tls:
 
 1. Choose a name for your configuration (must end with `.caddy`).
 2. Enter the following details in the configuration field:
+
 ```sh
 *.shadowarcanist.com, shadowarcanist.com {
     tls /data/certs/shadowarcanist.cert /data/certs/shadowarcanist.key
@@ -256,6 +282,7 @@ tls:
 ---
 
 If you want to add multiple certificates and keys, you can do it like this:
+
 ```sh
 *.shadowarcanist.com, shadowarcanist.com {
     tls /data/certs/shadowarcanist.cert /data/certs/shadowarcanist.key
@@ -269,8 +296,8 @@ If you want to add multiple certificates and keys, you can do it like this:
     tls /data/certs/name3.cert /data/certs/name3.key
 }
 ```
-:::
 
+:::
 
 From now on, Coolify will use the origin certificate for requests matching the hostname.
 

--- a/docs/integrations/cloudflare/tunnels/overview.md
+++ b/docs/integrations/cloudflare/tunnels/overview.md
@@ -29,14 +29,14 @@ This makes them a great option for hosting projects on devices like old laptops 
 
 You can set up Cloudflare Tunnels with Coolify in several ways, depending on your needs. Below are the available options, each linked to a detailed guide for easy setup:
 
-1. [All Resources](/knowledge-base/cloudflare/tunnels/all-resource) -> Use a tunnel for all resources deployed through Coolify. This is the **easiest** and **most recommended** way for beginners.
+1. [All Resources](/integrations/cloudflare/tunnels/all-resource) -> Use a tunnel for all resources deployed through Coolify. This is the **easiest** and **most recommended** way for beginners.
 
-2. [Single Resource](/knowledge-base/cloudflare/tunnels/single-resource) -> Use a tunnel for a single resource deployed through Coolify.
+2. [Single Resource](/integrations/cloudflare/tunnels/single-resource) -> Use a tunnel for a single resource deployed through Coolify.
 
-3. [Server SSH Access](/knowledge-base/cloudflare/tunnels/server-ssh) -> Securely connect your server to Coolify using a domain through Cloudflare Tunnel.
+3. [Server SSH Access](/integrations/cloudflare/tunnels/server-ssh) -> Securely connect your server to Coolify using a domain through Cloudflare Tunnel.
 
-4. [Full HTTPS/TLS](/knowledge-base/cloudflare/tunnels/full-tls) -> Setup always-on **HTTPS** for all domains and subdomains. Normally, Coolify uses **HTTP** while Cloudflare manages **HTTPS**. If certain apps require **HTTPS** directly on Coolify.
+4. [Full HTTPS/TLS](/integrations/cloudflare/tunnels/full-tls) -> Setup always-on **HTTPS** for all domains and subdomains. Normally, Coolify uses **HTTP** while Cloudflare manages **HTTPS**. If certain apps require **HTTPS** directly on Coolify.
 
 ::: success Tip:
-It’s highly recommended to go with the first option [All Resources](/knowledge-base/cloudflare/tunnels/all-resource) if you're new to Coolify and Cloudflare Tunnels, as it’s much easier to set up and manage.
+It’s highly recommended to go with the first option [All Resources](/integrations/cloudflare/tunnels/all-resource) if you're new to Coolify and Cloudflare Tunnels, as it’s much easier to set up and manage.
 :::

--- a/docs/integrations/cloudflare/tunnels/single-resource.md
+++ b/docs/integrations/cloudflare/tunnels/single-resource.md
@@ -27,7 +27,7 @@ To follow this guide, you'll need:
 ## Before We Start
 
 - We assume you have Coolify running and an app already deployed.
-- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/knowledge-base/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
+- If your app requires HTTPS for functionality like cookies or login, then you need to follow the [Full TLS HTTPS guide](/integrations/cloudflare/tunnels/full-tls) after following this guide. This is because in this guide, Cloudflare will manage HTTPS externally, while your app will run over HTTP within Coolify.
 
 ## How It Works?
 
@@ -131,7 +131,7 @@ Go to the **Environment Variables** page, enter your tunnel token, and deploy th
 
 ## Tunnel Multiple Resources
 
-The easiest way to tunnel multiple resources is by following our [Tunnel All Resources](/knowledge-base/cloudflare/tunnels/all-resource) guide, which uses Coolify's built-in proxy. However, if you prefer not to use the proxy, there are two alternative methods:
+The easiest way to tunnel multiple resources is by following our [Tunnel All Resources](/integrations/cloudflare/tunnels/all-resource) guide, which uses Coolify's built-in proxy. However, if you prefer not to use the proxy, there are two alternative methods:
 
 - [Tunnel Multiple Single Resources](#tunnel-multiple-single-resources)
 - [Tunnel Coolify](#tunnel-coolify)
@@ -140,7 +140,7 @@ Tunneling multiple single resources is straightforward, but tunneling Coolify it
 
 ## Tunnel Multiple Single Resources
 
-If you want to expose different apps individually, you can follow our [Tunnel All Resources](/knowledge-base/cloudflare/tunnels/all-resource), or take an alternate approach:
+If you want to expose different apps individually, you can follow our [Tunnel All Resources](/integrations/cloudflare/tunnels/all-resource), or take an alternate approach:
 
 <ZoomableImage src="/docs/images/integrations/cloudflare/tunnels/single-resource/11.webp" />
 
@@ -160,7 +160,6 @@ Follow [Step 2](#_2-create-a-cloudflare-tunnel) from the main guide to create pu
 <ZoomableImage src="/docs/images/integrations/cloudflare/tunnels/single-resource/14.webp" />
 
 - **Hostnames**:
-
   1. `app.shadowarcanist.com/terminal/ws` → `localhost:6002` (WebSocket terminal)
   2. `realtime.shadowarcanist.com` → `localhost:6001` (Realtime server)
   3. `app.shadowarcanist.com` → `localhost:8000` (Coolify dashboard)


### PR DESCRIPTION
This pull request updates the Cloudflare Tunnels integration documentation for Coolify, primarily to standardize and correct internal documentation links and improve clarity in certificate setup instructions. The most important changes are grouped below.

### Documentation Link Updates

* Updated all internal documentation links from `/knowledge-base/cloudflare/tunnels/...` to `/integrations/cloudflare/tunnels/...` across all guides to ensure consistency and prevent broken links.