### PR TITLE
Fix typo in API authorization base route

### DIFF
--- a/docs/api-reference/authorization.md
+++ b/docs/api-reference/authorization.md
@@ -11,7 +11,7 @@ API request requires a `Bearer` token in `Authorization` header, which could be 
 
 The API can be accessed through `http://<ip>:8000/api`.
 
-With the exception of `/health` and `/feedback`, all routes are additionally prefixed with `/v1` resulting in the base rouce `http://<ip>:8000/api/v1`.
+With the exception of `/health` and `/feedback`, all routes are additionally prefixed with `/v1` resulting in the base route `http://<ip>:8000/api/v1`.
 
 ## Generate
 


### PR DESCRIPTION
Corrected a typo in the authorization documentation.