### PR TITLE
docs(traefik): add custom middlewares guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -430,9 +430,16 @@ export default defineConfig({
                       { text: 'Basic Auth', link: '/knowledge-base/proxy/traefik/basic-auth' },
                       { text: 'Custom SSL Certificates', link: '/knowledge-base/proxy/traefik/custom-ssl-certs' },
                       { text: 'Dashboard', link: '/knowledge-base/proxy/traefik/dashboard' },
+                      {
+                        text: 'Custom Middlewares',
+                        link: '/knowledge-base/proxy/traefik/custom-middlewares',
+                        collapsed: true,
+                        items: [
+                          { text: 'Redirects', link: '/knowledge-base/proxy/traefik/redirects' },
+                        ]
+                      },
                       { text: 'Dynamic Configurations', link: '/knowledge-base/proxy/traefik/dynamic-config' },
                       { text: 'Load Balancing', link: '/knowledge-base/proxy/traefik/load-balancing' },
-                      { text: 'Redirects', link: '/knowledge-base/proxy/traefik/redirects' },
                       { text: 'Wildcard SSL Certificates', link: '/knowledge-base/proxy/traefik/wildcard-certs' },
                       { text: 'Protect Services with Authentik', link: '/knowledge-base/proxy/traefik/protect-services-with-authentik' }
                     ]

--- a/docs/knowledge-base/proxy/traefik/custom-middlewares.md
+++ b/docs/knowledge-base/proxy/traefik/custom-middlewares.md
@@ -1,0 +1,212 @@
+---
+title: "Custom Middlewares"
+description: "Apply custom Traefik middlewares to Coolify applications and Docker Compose services for rate limiting, IP whitelisting, custom headers, and more."
+---
+
+# Custom Middlewares
+
+Traefik [middlewares](https://doc.traefik.io/traefik/middlewares/overview/?utm_source=coolify.io) let you tweak requests before they reach your application — adding headers, rate limiting, IP whitelisting, and more.
+
+How you apply a custom middleware in Coolify depends on your deployment type:
+
+- **Standard Applications** — edit the Container Labels directly.
+- **Docker Compose** — use a Coolify shorthand label or define labels in your `docker-compose.yml`.
+
+Both approaches can reference middlewares defined **inline** (in Docker labels) or **externally** (in Traefik's [dynamic configuration](/knowledge-base/proxy/traefik/dynamic-config)).
+
+## Standard Applications
+
+For standard (non-Docker Compose) applications, you configure middlewares by editing the **Container Labels** in the Coolify UI.
+
+### Steps
+
+1. Open your application in Coolify and scroll to the **Container Labels** section.
+2. Uncheck **Readonly labels** so the label textarea becomes editable.
+3. Add your middleware definition label(s). For example, to add rate limiting:
+
+   ```bash
+   traefik.http.middlewares.my-ratelimit.ratelimit.average=100
+   traefik.http.middlewares.my-ratelimit.ratelimit.period=1m
+   ```
+
+4. Find the existing `traefik.http.routers.https-0-<uuid>.middlewares=...` line and **append** your middleware name to it:
+
+   ```bash
+   traefik.http.routers.https-0-<uuid>.middlewares=gzip,my-ratelimit
+   ```
+
+5. Save and redeploy.
+
+::: warning Important
+When you uncheck **Readonly labels**, Coolify stops auto-generating labels on deploy. You are responsible for keeping all routing labels correct. If you break the labels, your application may become unreachable.
+
+Use the **Reset Labels to Defaults** button to restore auto-generated labels if needed.
+:::
+
+### Full Example
+
+Given Coolify generated labels like:
+
+```bash
+traefik.enable=true
+traefik.http.middlewares.gzip.compress=true
+traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https
+traefik.http.routers.http-0-abc123.entryPoints=http
+traefik.http.routers.http-0-abc123.middlewares=redirect-to-https
+traefik.http.routers.http-0-abc123.rule=Host(`app.example.com`) && PathPrefix(`/`)
+traefik.http.routers.http-0-abc123.service=http-0-abc123
+traefik.http.routers.https-0-abc123.entryPoints=https
+traefik.http.routers.https-0-abc123.middlewares=gzip
+traefik.http.routers.https-0-abc123.rule=Host(`app.example.com`) && PathPrefix(`/`)
+traefik.http.routers.https-0-abc123.service=https-0-abc123
+traefik.http.routers.https-0-abc123.tls.certresolver=letsencrypt
+traefik.http.routers.https-0-abc123.tls=true
+traefik.http.services.http-0-abc123.loadbalancer.server.port=3000
+traefik.http.services.https-0-abc123.loadbalancer.server.port=3000
+```
+
+To add a custom headers middleware, add a definition and update the router:
+
+```bash
+traefik.http.middlewares.security-headers.headers.browserXssFilter=true
+traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true
+traefik.http.middlewares.security-headers.headers.frameDeny=true
+traefik.http.routers.https-0-abc123.middlewares=gzip,security-headers // [!code focus]
+```
+
+## Docker Compose Services
+
+For Docker Compose deployments, Coolify provides a **shorthand label** that automatically injects your middleware into the router chain — no need to manually edit router labels.
+
+### Using the Coolify Shorthand
+
+Add `coolify.traefik.middlewares` to your service labels:
+
+```yaml
+services:
+  myapp:
+    image: nginx:alpine
+    labels:
+      - "traefik.http.middlewares.my-ratelimit.ratelimit.average=100"
+      - "traefik.http.middlewares.my-ratelimit.ratelimit.period=1m"
+      - "coolify.traefik.middlewares=my-ratelimit" # [!code focus]
+```
+
+Coolify reads this label during deployment, extracts the middleware name, and appends it to the router's middleware chain alongside built-in middlewares like `gzip`.
+
+For multiple middlewares, separate them with commas:
+
+```yaml
+labels:
+  - "coolify.traefik.middlewares=my-ratelimit,security-headers"
+```
+
+::: tip
+The `coolify.traefik.middlewares` label is consumed by Coolify during label generation and does not appear on the running container. It is a deployment-time directive, not a Docker label.
+:::
+
+## Using External Middlewares (`@file`)
+
+If you have a middleware defined in Traefik's [dynamic configuration](/knowledge-base/proxy/traefik/dynamic-config), you can reference it by appending `@file` to its name. This avoids duplicating middleware definitions across multiple applications.
+
+### 1. Define the Middleware in Dynamic Configuration
+
+Go to **Server** → **Proxy** → **Dynamic Configurations** and create a new config file:
+
+```yaml
+http:
+  middlewares:
+    my-ipallowlist:
+      ipAllowList:
+        sourceRange:
+          - "192.168.1.0/24"
+          - "10.0.0.0/8"
+```
+
+### 2. Reference It in Your Application
+
+**Standard Application** — update the router middlewares line:
+
+```bash
+traefik.http.routers.https-0-abc123.middlewares=gzip,my-ipallowlist@file
+```
+
+**Docker Compose** — use the shorthand:
+
+```yaml
+labels:
+  - "coolify.traefik.middlewares=my-ipallowlist@file"
+```
+
+::: info
+The `@file` suffix tells Traefik to look for the middleware in its file-based dynamic configuration rather than in Docker labels. This is the standard Traefik [provider namespace syntax](https://doc.traefik.io/traefik/providers/overview/?utm_source=coolify.io#provider-namespace).
+:::
+
+## Common Middleware Examples
+
+### Rate Limiting
+
+See [Traefik RateLimit reference](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/ratelimit/?utm_source=coolify.io) for all available options.
+
+```bash
+traefik.http.middlewares.my-ratelimit.ratelimit.average=100
+traefik.http.middlewares.my-ratelimit.ratelimit.period=1m
+traefik.http.middlewares.my-ratelimit.ratelimit.burst=50
+```
+
+### Custom Headers
+
+See [Traefik Headers reference](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/headers/?utm_source=coolify.io) for all available options.
+
+```bash
+traefik.http.middlewares.security-headers.headers.browserXssFilter=true
+traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true
+traefik.http.middlewares.security-headers.headers.frameDeny=true
+traefik.http.middlewares.security-headers.headers.stsSeconds=31536000
+traefik.http.middlewares.security-headers.headers.stsIncludeSubdomains=true
+```
+
+### IP Whitelisting
+
+See [Traefik IPAllowList reference](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/ipallowlist/?utm_source=coolify.io) for all available options.
+
+```bash
+traefik.http.middlewares.my-ipwhitelist.ipallowlist.sourcerange=192.168.1.0/24,10.0.0.0/8
+```
+
+### Redirects
+
+For www/non-www redirects and domain forwarding, see the dedicated [Redirects](/knowledge-base/proxy/traefik/redirects) guide, which also covers Coolify's built-in Direction setting.
+
+::: info
+Find more middleware examples in the official [Traefik documentation](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/overview?utm_source=coolify.io).
+:::
+
+## Label Escaping
+
+When your middleware labels contain special characters like `$` (common in basic auth hashes), Coolify provides an **Escape special characters in labels** checkbox in the Container Labels section.
+
+When enabled, `$` characters are escaped to `$$` to prevent Docker from interpreting them as environment variable references.
+
+::: warning
+If you use dollar signs (`$`) in label values (e.g., bcrypt hashes) and do **not** enable escaping, Docker will attempt to expand them as variables, leading to broken configurations.
+:::
+
+## Troubleshooting
+
+### Middleware Not Applied
+
+- **Standard app**: Verify you added the middleware name to the `traefik.http.routers.*.middlewares` label. Defining the middleware alone is not enough — it must be referenced in the router.
+- **Docker Compose**: Confirm the `coolify.traefik.middlewares` label is present and the middleware name matches exactly.
+- Check Traefik's dashboard (if enabled) to see if the middleware is registered under your router.
+
+### Application Unreachable After Editing Labels
+
+- If you edited labels on a standard application and broke routing, use the **Reset Labels to Defaults** button, re-enable **Readonly labels**, and redeploy.
+- If using Docker Compose, check your `docker-compose.yml` syntax for quoting issues.
+
+### `@file` Middleware Not Found
+
+- Ensure the dynamic config file is saved in the correct location and Traefik has reloaded it.
+- Verify the middleware name in the config matches what you reference (case-sensitive).
+- Check for YAML syntax errors in the dynamic config.

--- a/docs/knowledge-base/proxy/traefik/overview.md
+++ b/docs/knowledge-base/proxy/traefik/overview.md
@@ -35,13 +35,13 @@ Below are some of the key features and ways you can use Traefik with Coolify:
 
 3. [Dashboard](/knowledge-base/proxy/traefik/dashboard) -> Enable Traefik’s built-in dashboard for real-time monitoring and insights.
 
-4. [Dynamic Configuration](/knowledge-base/proxy/traefik/dynamic-config) -> Manage dynamic configuration changes like routing rules or middlewares.
+4. [Custom Middlewares](/knowledge-base/proxy/traefik/custom-middlewares) -> Apply custom Traefik middlewares like rate limiting, IP whitelisting, redirects, custom headers, and more.
 
-5. [Health Checks](/knowledge-base/health-checks) -> Configure health checks to ensure your applications are running smoothly.
+5. [Dynamic Configuration](/knowledge-base/proxy/traefik/dynamic-config) -> Manage dynamic configuration changes like routing rules or middlewares.
 
-6. [Load Balancing](/knowledge-base/proxy/traefik/load-balancing) -> Distribute traffic across multiple app instances for better performance.
+6. [Health Checks](/knowledge-base/health-checks) -> Configure health checks to ensure your applications are running smoothly.
 
-7. [Redirects](/knowledge-base/proxy/traefik/redirects) -> Set up HTTP-to-HTTPS redirection or create specific URL redirects.
+7. [Load Balancing](/knowledge-base/proxy/traefik/load-balancing) -> Distribute traffic across multiple app instances for better performance.
 
 8. [Wildcard Certificates](/knowledge-base/proxy/traefik/wildcard-certs) -> Secure multiple subdomains with a single SSL certificate.
 

--- a/docs/knowledge-base/proxy/traefik/redirects.md
+++ b/docs/knowledge-base/proxy/traefik/redirects.md
@@ -5,50 +5,67 @@ description: "Configure Traefik URL redirects in Coolify including www to non-ww
 
 # Redirects with Traefik
 
-This guide will help you to configure redirects in Coolify with Traefik.
+This guide covers how to configure URL redirects in Coolify with Traefik, including the built-in redirect settings and manual middleware configuration.
 
-The configuration is slightly different for `Standard Applications` and `Docker Compose` based applications/one-click services.
+## Built-in www / non-www Redirect
 
-## Standard Applications
+Coolify has a built-in **Direction** setting for www and non-www redirects. When **Readonly labels** is enabled (the default), you can select the redirect behavior from the application settings without editing labels manually.
 
-- You need to set both FQDNs for your resource, so for example: `coolify.io,www.coolify.io`
-- Add a unique middleware to your resource.
+The available options are:
 
-### www -> non-www
+| Direction | Behavior |
+|-----------|----------|
+| **Allow both** | No redirect. Both `www.` and non-`www.` URLs work. |
+| **Redirect to www** | Redirects non-www requests to the `www.` variant. |
+| **Redirect to non-www** | Redirects `www.` requests to the non-www variant. |
+
+::: tip
+To use this setting, make sure both URLs are configured for your application (e.g., `https://coolify.io,https://www.coolify.io`) and **Readonly labels** is enabled.
+:::
+
+::: info
+When **Readonly labels** is disabled, the Direction field becomes read-only because Coolify can no longer auto-generate the redirect labels. In that case, follow the manual configuration below.
+:::
+
+## Manual Redirect Configuration
+
+For custom redirects — or when Readonly labels is disabled — you configure redirects using Traefik's `redirectregex` middleware in your Container Labels.
+
+The setup differs slightly between [Standard Applications](#standard-applications) and [Docker Compose](#docker-compose-and-services) deployments.
+
+### Standard Applications
+
+You need to set both URLs for your resource (e.g., `https://coolify.io,https://www.coolify.io`), then add the middleware and reference it in the router.
+
+#### www -> non-www
 
 ```bash
-# A similar line is already defined.
-traefik.http.routers.<unique_router_name>.rule=Host(`www.coolify.io`) && PathPrefix(`/`)
+# Define the redirect middleware
+traefik.http.middlewares.example-redirect.redirectregex.regex=^(http|https)://www\.(.+)
+traefik.http.middlewares.example-redirect.redirectregex.replacement=${1}://${2}
+traefik.http.middlewares.example-redirect.redirectregex.permanent=true
 
-# You need to add the middleware to the router.
-traefik.http.routers.<unique_router_name>.middlewares=example-middleware
-
-# If you have multiple middlewares, you need to add them comma separated.
-# traefik.http.routers.<unique_router_name>.middlewares=gzip,example-middleware
-#
-traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://www\.(.+)
-traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://${2}
-traefik.http.middlewares.example-middleware.redirectregex.permanent=true
+# Add it to the router (append to existing middlewares)
+traefik.http.routers.<unique_router_name>.middlewares=gzip,example-redirect
 ```
 
-### non-www -> www
+#### non-www -> www
 
 ```bash
-# A similar line is already defined.
-traefik.http.routers.<unique_router_name>.rule=Host(`coolify.io`) && PathPrefix(`/`)
+# Define the redirect middleware
+traefik.http.middlewares.example-redirect.redirectregex.regex=^(http|https)://(?:www\.)?(.+)
+traefik.http.middlewares.example-redirect.redirectregex.replacement=${1}://www.${2}
+traefik.http.middlewares.example-redirect.redirectregex.permanent=true
 
-# You need to add the middleware to the router.
-traefik.http.routers.<unique_router_name>.middlewares=example-middleware
-
-# If you have multiple middlewares, you need to add them comma separated.
-# traefik.http.routers.<unique_router_name>.middlewares=gzip,example-middleware
-#
-traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://(?:www\.)?(.+)
-traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://www.${2}
-traefik.http.middlewares.example-middleware.redirectregex.permanent=true
+# Add it to the router (append to existing middlewares)
+traefik.http.routers.<unique_router_name>.middlewares=gzip,example-redirect
 ```
 
-### domain -> other domain
+::: info
+The `<unique_router_name>` is the router name Coolify generated for you (e.g., `https-0-wc04wo4ow4scokgsw8wow4s8`). Find it in your existing Container Labels.
+:::
+
+#### Domain -> Other Domain
 
 ```bash
 traefik.http.middlewares.redirect-otherdomain.redirectregex.regex=^(https?://)?source-domain\.com(.*)
@@ -56,55 +73,62 @@ traefik.http.middlewares.redirect-otherdomain.redirectregex.replacement=https://
 traefik.http.middlewares.redirect-otherdomain.redirectregex.permanent=true
 ```
 
-If you also need to generate a ssl cert for the target-domain, additionally add a routers entry
+If you also need to generate an SSL certificate for the source domain, add a router entry for it:
 
 ```bash
 traefik.http.routers.redirect-otherdomain.middlewares=redirect-to-https,redirect-otherdomain
-traefik.http.routers.redirect-otherdomain.rule=Host(`target-domain.com`) && PathPrefix(`/`)
+traefik.http.routers.redirect-otherdomain.rule=Host(`source-domain.com`) && PathPrefix(`/`)
 traefik.http.routers.redirect-otherdomain.entryPoints=https
 traefik.http.routers.redirect-otherdomain.tls.certresolver=letsencrypt
 traefik.http.routers.redirect-otherdomain.tls=true
 ```
 
-## Docker Compose based Applications & one-click Services
+### Docker Compose and Services
 
-- You need to set both FQDNs for your resource, so for example: `coolify.io,www.coolify.io`
-- You only need add the middleware to the router.
+For Docker Compose deployments, define the middleware labels in your `docker-compose.yml` and use the `coolify.traefik.middlewares` shorthand to attach them to the router automatically.
 
-### www -> non-www
+Make sure both URLs are set for your resource (e.g., `https://coolify.io,https://www.coolify.io`).
 
-```bash
-traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://www\.(.+)
-traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://${2}
-traefik.http.middlewares.example-middleware.redirectregex.permanent=true
+#### www -> non-www
+
+```yaml
+labels:
+  - "traefik.http.middlewares.example-redirect.redirectregex.regex=^(http|https)://www\\.(.+)"
+  - "traefik.http.middlewares.example-redirect.redirectregex.replacement=$${1}://$${2}"
+  - "traefik.http.middlewares.example-redirect.redirectregex.permanent=true"
+  - "coolify.traefik.middlewares=example-redirect"
 ```
 
-### non-www -> www
+#### non-www -> www
 
-```bash
-traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://(?:www\.)?(.+)
-traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://www.${2}
-traefik.http.middlewares.example-middleware.redirectregex.permanent=true
+```yaml
+labels:
+  - "traefik.http.middlewares.example-redirect.redirectregex.regex=^(http|https)://(?:www\\.)?(.+)"
+  - "traefik.http.middlewares.example-redirect.redirectregex.replacement=$${1}://www.$${2}"
+  - "traefik.http.middlewares.example-redirect.redirectregex.permanent=true"
+  - "coolify.traefik.middlewares=example-redirect"
 ```
+
+::: warning
+In Docker Compose YAML, dollar signs (`$`) must be escaped as `$$` to prevent Docker from interpreting them as environment variable references.
+:::
 
 ## Debugging
 
-You can check, if the traefik settings have been correctly applied, when inspecting your docker target container.
+Check whether the Traefik labels were correctly applied by inspecting your container:
 
-Find your docker container id
 ```bash
+# Find your container ID
 docker ps
-```
 
-Inspect the containers labels
-
-```bash
+# Inspect the container's labels
 docker inspect <container-id>
 ```
 
-You can additionally check the traefik container logs, by running
+You can additionally check the Traefik container logs:
 
 ```bash
 docker logs -f coolify-proxy
 ```
 
+For more details on applying custom middlewares, see the [Custom Middlewares](/knowledge-base/proxy/traefik/custom-middlewares) guide.


### PR DESCRIPTION
## Summary

- Add a new **Custom Middlewares** guide covering how to apply custom Traefik middlewares to Coolify applications (standard apps via Container Labels and Docker Compose via `coolify.traefik.middlewares` shorthand), including external `@file` middleware references, common examples with links to Traefik docs, label escaping, and troubleshooting.
- Update the **Redirects** guide to document Coolify's built-in **Direction** dropdown for www/non-www redirects, add `coolify.traefik.middlewares` usage for Docker Compose, and fix `$` escaping in YAML examples.
- Nest **Redirects** under **Custom Middlewares** in the sidebar and update the **Traefik Overview** page.

Addresses [coollabsio/coolify#7869](https://github.com/coollabsio/coolify/discussions/7869)

## Test plan

- [ ] Verify example code
- [x] Confirm sidebar renders correctly with nested Custom Middlewares > Redirects
- [x] Test internal links between custom-middlewares.md and redirects.md
- [x] Verify external Traefik doc links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)