### PR TITLE
docs(service): add openreplay service page

### DIFF
--- a/docs/public/images/services/openreplay.svg
+++ b/docs/public/images/services/openreplay.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#E7313B"/>
+  <path d="M38 28 L72 50 L38 72 Z" fill="#ffffff"/>
+</svg>

--- a/docs/services/all.md
+++ b/docs/services/all.md
@@ -48,6 +48,7 @@ Complete directory of all one-click services available in Coolify, organized by 
 - [GoatCounter](/services/goatcounter) - A web analytics platform that aims to offer easy to use and meaningful privacy-friendly web analytics.
 - [Metabase](/services/metabase) - The simplest, fastest way to share data and analytics inside your company
 - [OpenPanel](/services/openpanel) - Open source alternative to Mixpanel and Plausible for product analytics
+- [OpenReplay](/services/openreplay) - Open-source session replay and product analytics platform for debugging user journeys
 - [PostHog](/services/posthog) - Open source product analytics
 - [Plausible](/services/plausible) - A lightweight, open-source web analytics tool that prioritizes user privacy by not using cookies
 - [Rybbit](/services/rybbit) - Next-gen, open source, lightweight, cookieless web & product analytics for everyone

--- a/docs/services/openreplay.md
+++ b/docs/services/openreplay.md
@@ -27,6 +27,18 @@ The Coolify one-click template deploys OpenReplay with its required components, 
 - Keep persistent volumes enabled for PostgreSQL, ClickHouse, and MinIO.
 - Verify healthchecks for database and migration services before first login.
 
+## Before You Start
+
+- Plan for at least a medium instance profile (multiple services run together: database, object storage, analytics, frontend).
+- Confirm your Coolify server has enough disk I/O headroom for ClickHouse and replay storage growth.
+- Decide your public URL before first deploy so callbacks and links stay consistent.
+
+## Post-Deployment Checklist
+
+1. Open the dashboard and create a test project.
+2. Send one sample replay from the tracker snippet and confirm it appears in sessions.
+3. Verify ClickHouse/PostgreSQL/MinIO services are healthy after the first restart.
+
 ## Links
 
 - [OpenReplay Website](https://openreplay.com/?utm_source=coolify.io)

--- a/docs/services/openreplay.md
+++ b/docs/services/openreplay.md
@@ -1,0 +1,34 @@
+---
+title: "OpenReplay"
+description: "Deploy OpenReplay on Coolify to self-host session replay and product analytics with full control over your data."
+---
+
+# OpenReplay
+
+<ZoomableImage src="/docs/images/services/openreplay.svg" alt="OpenReplay" />
+
+## What is OpenReplay?
+
+OpenReplay is an open-source session replay and product analytics platform. It helps teams debug issues by replaying real user sessions, inspecting frontend events, and correlating them with backend signals.
+
+## Deployment Notes
+
+The Coolify one-click template deploys OpenReplay with its required components, including:
+
+- PostgreSQL
+- ClickHouse
+- Redis/Valkey
+- MinIO object storage
+- OpenReplay API, ingestion, frontend, and supporting services
+
+## Recommended Setup
+
+- Use a dedicated domain for `nginx-openreplay`.
+- Keep persistent volumes enabled for PostgreSQL, ClickHouse, and MinIO.
+- Verify healthchecks for database and migration services before first login.
+
+## Links
+
+- [OpenReplay Website](https://openreplay.com/?utm_source=coolify.io)
+- [Documentation](https://docs.openreplay.com/?utm_source=coolify.io)
+- [GitHub Repository](https://github.com/openreplay/openreplay)


### PR DESCRIPTION
### Changes

- Add OpenReplay service documentation page at `docs/services/openreplay.md`.
- Add OpenReplay service icon at `docs/public/images/services/openreplay.svg`.
- Add OpenReplay entry to `docs/services/all.md` under Analytics.

### Related

- Coolify service PR: https://github.com/coollabsio/coolify/pull/8486
- Issue: https://github.com/coollabsio/coolify/issues/8232

### Steps to Test

1. Run docs locally and open `/services/openreplay`.
2. Verify the page renders with icon and sections (What is, Deployment Notes, Recommended Setup, Links).
3. Open `/services/all` and confirm OpenReplay appears under Analytics.

### Merge Note

- This docs PR is ready from documentation side.
- The originally linked service PR (`coolify#8486`) was closed; current active implementation thread is `coolify#8443`.
- Maintainers can merge this docs PR together with whichever OpenReplay service template PR is selected for merge.
