### PR TITLE
docs(service): add wordpress openlitespeed mariadb variant

### DIFF
--- a/docs/services/wordpress.md
+++ b/docs/services/wordpress.md
@@ -31,6 +31,11 @@ WordPress is available in three deployment configurations in Coolify:
   - MariaDB container
   - First-run bootstrap that initializes WordPress files and `wp-config.php`
 
+#### Variant Notes (OpenLiteSpeed)
+- Best fit when you specifically want OpenLiteSpeed cache/performance behavior.
+- Keep persistent storage enabled so first-run generated files and uploads survive restarts.
+- If migrating from Apache/Nginx WordPress stacks, verify permalink/cache plugin behavior after cutover.
+
 ### WordPress with MySQL
 - **Database:** MySQL
 - **Use case:** Production deployments with MySQL preference

--- a/docs/services/wordpress.md
+++ b/docs/services/wordpress.md
@@ -12,7 +12,7 @@ It is used for creating websites, blogs, and applications.
 
 ## Deployment Variants
 
-WordPress is available in two deployment configurations in Coolify:
+WordPress is available in three deployment configurations in Coolify:
 
 ### WordPress with MariaDB
 - **Database:** MariaDB
@@ -22,6 +22,15 @@ WordPress is available in two deployment configurations in Coolify:
   - MariaDB container
   - Automatic database configuration and health checks
 
+### WordPress with OpenLiteSpeed + MariaDB
+- **Web Server:** OpenLiteSpeed
+- **Database:** MariaDB
+- **Use case:** Users who prefer OpenLiteSpeed while keeping MariaDB as the database backend
+- **Components:**
+  - OpenLiteSpeed + WordPress container
+  - MariaDB container
+  - First-run bootstrap that initializes WordPress files and `wp-config.php`
+
 ### WordPress with MySQL
 - **Database:** MySQL
 - **Use case:** Production deployments with MySQL preference
@@ -30,7 +39,7 @@ WordPress is available in two deployment configurations in Coolify:
   - MySQL container
   - Automatic database configuration and health checks
 
-Both variants provide equivalent functionality - choose based on your database preference or existing infrastructure.
+All variants provide equivalent core functionality - choose based on your preferred web server and database stack.
 
 ## Links
 


### PR DESCRIPTION
### Changes

- Update `docs/services/wordpress.md` to include the new **WordPress with OpenLiteSpeed + MariaDB** deployment variant.
- Clarify variant summary text to reflect three supported WordPress variants.

### Related

- Coolify service PR: https://github.com/coollabsio/coolify/pull/8487
- Issue: https://github.com/coollabsio/coolify/issues/8264

### Steps to Test

1. Open `/services/wordpress` in local docs preview.
2. Verify the new `WordPress with OpenLiteSpeed + MariaDB` section is present under Deployment Variants.
3. Confirm all three variants are documented consistently.

### Merge Note

- This docs PR is ready from documentation side.
- The originally linked service PR (`coolify#8487`) was closed; current active implementation thread is `coolify#8271`.
- Maintainers can merge this docs PR together with whichever WordPress OpenLiteSpeed variant PR is selected for merge.
