### PR TITLE
docs(service): add docker mailserver service page

### DIFF
--- a/docs/public/images/services/docker-mailserver.svg
+++ b/docs/public/images/services/docker-mailserver.svg
@@ -1,0 +1,19 @@
+<svg width="500" height="500" viewBox="0 0 500 500" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs/>
+  <!-- Mail envelope background -->
+  <rect x="50" y="150" width="400" height="250" rx="20" ry="20" fill="#2563eb" stroke="#1e40af" stroke-width="2"/>
+  <!-- Envelope flap -->
+  <path d="M50 150 L250 280 L450 150" fill="#3b82f6" stroke="#1e40af" stroke-width="2"/>
+  <!-- Mail lines inside envelope -->
+  <rect x="100" y="220" width="300" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <rect x="100" y="250" width="250" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <rect x="100" y="280" width="200" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <!-- Docker container elements -->
+  <rect x="180" y="80" width="140" height="20" rx="10" fill="#0ea5e9" stroke="#0284c7" stroke-width="2"/>
+  <rect x="180" y="110" width="140" height="20" rx="10" fill="#06b6d4" stroke="#0891b2" stroke-width="2"/>
+  <!-- Server icon -->
+  <circle cx="100" cy="450" r="15" fill="#10b981"/>
+  <circle cx="150" cy="450" r="15" fill="#10b981"/>
+  <circle cx="200" cy="450" r="15" fill="#10b981"/>
+  <rect x="70" y="420" width="160" height="10" rx="5" fill="#059669"/>
+</svg>

--- a/docs/services/all.md
+++ b/docs/services/all.md
@@ -215,6 +215,7 @@ Complete directory of all one-click services available in Coolify, organized by 
 ## Email
 
 - [Open Archiver](/services/open-archiver) - Self-hosted, open-source email archiving solution with full-text search
+- [Docker Mailserver](/services/docker-mailserver) - Fullstack self-hosted mail server with SMTP, IMAP, and anti-spam tooling
 - [Sessy](/services/sessy) - Email observability platform for monitoring Amazon SES deliveries, bounces, and more
 - [Usesend](/services/usesend) - An open source bulk email manager
 

--- a/docs/services/docker-mailserver.md
+++ b/docs/services/docker-mailserver.md
@@ -26,6 +26,14 @@ The Coolify one-click template configures:
 - Set up valid DNS records (MX, SPF, DKIM, DMARC) for deliverability.
 - Provide TLS certificates and verify `SSL_TYPE` according to your setup.
 
+## DNS and Deliverability Checklist
+
+1. MX record points to the same host as `MAILSERVER_HOSTNAME`.
+2. SPF record includes your outbound mail host.
+3. DKIM key is generated/published before enabling outbound production traffic.
+4. DMARC policy starts with monitoring mode (`p=none`) and is tightened after validation.
+5. Reverse DNS (PTR) is aligned with your sending hostname when possible.
+
 ## Links
 
 - [Docker Mailserver Documentation](https://docker-mailserver.github.io/docker-mailserver/latest/?utm_source=coolify.io)

--- a/docs/services/docker-mailserver.md
+++ b/docs/services/docker-mailserver.md
@@ -1,0 +1,32 @@
+---
+title: "Docker Mailserver"
+description: "Deploy Docker Mailserver on Coolify to self-host a full email stack with SMTP, IMAP, and modern mail security defaults."
+---
+
+# Docker Mailserver
+
+<ZoomableImage src="/docs/images/services/docker-mailserver.svg" alt="Docker Mailserver" />
+
+## What is Docker Mailserver?
+
+Docker Mailserver is a production-ready self-hosted email server stack. It bundles Postfix, Dovecot, and common mail security components in a single deployable setup.
+
+## Deployment Notes
+
+The Coolify one-click template configures:
+
+- SMTP + submission ports (`25`, `465`, `587`)
+- IMAP ports (`143`, `993`) and ManageSieve (`4190`)
+- Persistent volumes for mail data, state, logs, and configuration
+- Common mail hardening defaults (DKIM, DMARC, SPF policy support)
+
+## Recommended Setup
+
+- Configure `MAILSERVER_HOSTNAME` and `POSTMASTER_ADDRESS` before production use.
+- Set up valid DNS records (MX, SPF, DKIM, DMARC) for deliverability.
+- Provide TLS certificates and verify `SSL_TYPE` according to your setup.
+
+## Links
+
+- [Docker Mailserver Documentation](https://docker-mailserver.github.io/docker-mailserver/latest/?utm_source=coolify.io)
+- [GitHub Repository](https://github.com/docker-mailserver/docker-mailserver)


### PR DESCRIPTION
### Changes

- Add Docker Mailserver service documentation page at `docs/services/docker-mailserver.md`.
- Add Docker Mailserver icon at `docs/public/images/services/docker-mailserver.svg`.
- Add Docker Mailserver entry to `docs/services/all.md` under Email.

### Related

- Coolify service PR: https://github.com/coollabsio/coolify/pull/8488
- Issue: https://github.com/coollabsio/coolify/issues/8266

### Steps to Test

1. Run docs locally and open `/services/docker-mailserver`.
2. Verify the page renders with deployment notes and recommended setup.
3. Open `/services/all` and confirm Docker Mailserver appears under Email.

### Merge Note

- This docs PR is ready from documentation side.
- The originally linked service PR (`coolify#8488`) was closed; current active implementation thread is `coolify#8275`.
- Maintainers can merge this docs PR together with whichever Docker Mailserver service PR is selected for merge.
