### PR TITLE
docs(services): fix broken Drizzle Gateway image link

### DIFF
--- a/docs/services/drizzle-gateway.md
+++ b/docs/services/drizzle-gateway.md
@@ -5,7 +5,7 @@ description: "Deploy and host Drizzle Studio with Coolify to explore SQL databas
 
 # Drizzle Gateway
 
-<ZoomableImage src="/docs/images/services/drizzle.jpeg" />
+<ZoomableImage src="/docs/images/services/drizzle-logo.jpeg" />
 
 ## What is Drizzle Gateway?
 


### PR DESCRIPTION
Fix image path from `drizzle.jpeg` to `drizzle-logo.jpeg` to match actual filename.