### PR TITLE
chore(services): Mark Booklore service as unavailable and remove from listings

### DIFF
--- a/docs/.vitepress/theme/components/Services/List.vue
+++ b/docs/.vitepress/theme/components/Services/List.vue
@@ -428,7 +428,8 @@ const services = [
         slug: 'booklore',
         icon: '/docs/images/services/booklore-logo.svg',
         description: 'Open-source library management system for your digital book collection.',
-        category: 'Media'
+        category: 'Media',
+        disabled: true
     },
     {
         name: 'Browserless',

--- a/docs/services/all.md
+++ b/docs/services/all.md
@@ -287,7 +287,6 @@ Complete directory of all one-click services available in Coolify, organized by 
 ## Media
 
 - [Audiobookshelf](/services/audiobookshelf) - Self-hosted audiobook and podcast server
-- [Booklore](/services/booklore) - Open-source library management system for your digital book collection
 - [Calibre-web](/services/calibre-web) - Web app for browsing, reading and downloading eBooks from a Calibre database
 - [Calibre Web Automated with Downloader](/services/calibre-web-automated-with-downloader) - Intuitive web interface for searching and requesting book downloads with Calibre-Web-Automated
 - [Cap](/services/cap) - Open source alternative to Loom for screen recording and sharing

--- a/docs/services/booklore.md
+++ b/docs/services/booklore.md
@@ -7,6 +7,10 @@ description: "Booklore is an open-source library management system for your digi
 
 <ZoomableImage src="/docs/images/services/booklore-logo.svg" alt="Booklore logo" />
 
+::: warning SERVICE NOT AVAILABLE
+This service has been removed from Coolify. BookLore is no longer maintained by its authors and removed by the authors from GitHub.
+:::
+
 ## What is Booklore?
 
 Booklore is an open-source library management system that gives you complete control over your digital book collection. Your books and data stay on your own server, ensuring privacy and independence.


### PR DESCRIPTION
## Summary
This PR marks the Booklore service as unavailable in Coolify due to the service no longer being maintained by its authors and being removed from GitHub.

## Core Issue
https://github.com/coollabsio/coolify/pull/9105

## Changes Made
- Added a warning notice to the Booklore documentation page indicating the service is no longer available
- Marked the Booklore service as disabled in the services list component to prevent users from attempting to deploy it
- Removed Booklore from the complete services directory listing under the Media category

## Implementation Details
- The service is disabled via a `disabled: true` flag in the services configuration, which will prevent it from being selectable in the UI
- A prominent warning box has been added at the top of the Booklore documentation to inform users that the service has been removed
- The service has been removed from the public-facing services directory to avoid confusion

https://claude.ai/code/session_016MvfbWFHT617CPApzPyn8i