### PR TITLE
docs(proxy): add DNS challenge documentation for Traefik & Caddy

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -444,6 +444,7 @@ export default defineConfig({
                       },
                       { text: 'Dynamic Configurations', link: '/knowledge-base/proxy/traefik/dynamic-config' },
                       { text: 'Load Balancing', link: '/knowledge-base/proxy/traefik/load-balancing' },
+                      { text: 'DNS Challenge', link: '/knowledge-base/proxy/traefik/dns-challenge' },
                       { text: 'Wildcard SSL Certificates', link: '/knowledge-base/proxy/traefik/wildcard-certs' },
                       { text: 'Protect Services with Authentik', link: '/knowledge-base/proxy/traefik/protect-services-with-authentik' }
                     ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -455,6 +455,7 @@ export default defineConfig({
                     items: [
                       { text: 'Overview', link: '/knowledge-base/proxy/caddy/overview' },
                       { text: 'Basic Auth', link: '/knowledge-base/proxy/caddy/basic-auth' },
+                      { text: 'DNS Challenge', link: '/knowledge-base/proxy/caddy/dns-challenge' },
                     ]
                   },
                 ]

--- a/docs/knowledge-base/proxy/caddy/dns-challenge.md
+++ b/docs/knowledge-base/proxy/caddy/dns-challenge.md
@@ -1,0 +1,186 @@
+---
+title: "DNS Challenge"
+description: "Switch Caddy from HTTP challenge to DNS challenge for ACME (Let's Encrypt) certificates — required for wildcard certs or servers without a public port 80."
+---
+
+# Switch Caddy to DNS Challenge
+
+By default, Coolify configures Caddy to obtain SSL certificates using the **HTTP challenge**, which requires port 80 to be publicly reachable. There are two common reasons to switch to the **DNS challenge** instead:
+
+- You want [wildcard SSL certificates](https://caddyserver.com/docs/automatic-https#wildcard-certificates) (e.g., `*.example.com`) — these *require* DNS challenge.
+- Your server does not have a public port 80 (e.g., internal network, behind a firewall, or a Tailscale-only node).
+
+## How It Works
+
+Instead of proving domain ownership over HTTP, Caddy asks your DNS provider to create a temporary `TXT` record under `_acme-challenge.<your-domain>`. Let's Encrypt reads that record to confirm ownership, then issues the certificate.
+
+Unlike Traefik, **Caddy DNS provider support must be compiled into the binary**. The default `lucaslorentz/caddy-docker-proxy` image does not include any DNS provider modules, so the configuration below uses a `dockerfile_inline` build to produce the correct binary automatically — no separate build step or registry required.
+
+## Prerequisites
+
+- A domain managed by a [supported DNS provider](https://github.com/orgs/caddy-dns/repositories?utm_source=coolify.io).
+- An API token / key for that provider with permission to create and delete DNS records.
+
+## Configuration
+
+Go to **Servers → your server → Proxy** and apply the changes shown below to your existing Caddy configuration.
+
+:::code-group
+
+```sh [Hetzner]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  caddy:
+    container_name: coolify-proxy
+    image: 'lucaslorentz/caddy-docker-proxy:2.8-alpine' # [!code --][!code focus]
+    build: # [!code ++][!code focus]
+      dockerfile_inline: | # [!code ++][!code focus]
+        FROM caddy:2.9-builder AS builder # [!code ++][!code focus]
+        RUN xcaddy build --with github.com/lucaslorentz/caddy-docker-proxy/v2 --with github.com/caddy-dns/hetzner # [!code ++][!code focus]
+        FROM caddy:2.9-alpine # [!code ++][!code focus]
+        COPY --from=builder /usr/bin/caddy /usr/bin/caddy # [!code ++][!code focus]
+        CMD ["caddy", "docker-proxy"] # [!code ++][!code focus]
+    restart: unless-stopped
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - CADDY_DOCKER_POLLING_INTERVAL=5s
+      - CADDY_DOCKER_CADDYFILE_PATH=/dynamic/Caddyfile
+      - HETZNER_API_TOKEN=<Hetzner API Token> # [!code ++][!code focus]
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    labels:
+      - coolify.managed=true
+      - coolify.proxy=true
+      - caddy.acme_dns=hetzner {env.HETZNER_API_TOKEN} # [!code ++][!code focus]
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/caddy/dynamic:/dynamic'
+      - '/data/coolify/proxy/caddy/config:/config'
+      - '/data/coolify/proxy/caddy/data:/data'
+```
+
+```sh [Cloudflare]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  caddy:
+    container_name: coolify-proxy
+    image: 'lucaslorentz/caddy-docker-proxy:2.8-alpine' # [!code --][!code focus]
+    build: # [!code ++][!code focus]
+      dockerfile_inline: | # [!code ++][!code focus]
+        FROM caddy:2.9-builder AS builder # [!code ++][!code focus]
+        RUN xcaddy build --with github.com/lucaslorentz/caddy-docker-proxy/v2 --with github.com/caddy-dns/cloudflare # [!code ++][!code focus]
+        FROM caddy:2.9-alpine # [!code ++][!code focus]
+        COPY --from=builder /usr/bin/caddy /usr/bin/caddy # [!code ++][!code focus]
+        CMD ["caddy", "docker-proxy"] # [!code ++][!code focus]
+    restart: unless-stopped
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - CADDY_DOCKER_POLLING_INTERVAL=5s
+      - CADDY_DOCKER_CADDYFILE_PATH=/dynamic/Caddyfile
+      - CF_API_TOKEN=<Cloudflare API Token> # [!code ++][!code focus]
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    labels:
+      - coolify.managed=true
+      - coolify.proxy=true
+      - caddy.acme_dns=cloudflare {env.CF_API_TOKEN} # [!code ++][!code focus]
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/caddy/dynamic:/dynamic'
+      - '/data/coolify/proxy/caddy/config:/config'
+      - '/data/coolify/proxy/caddy/data:/data'
+```
+
+
+```sh [Route53 (AWS)]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  caddy:
+    container_name: coolify-proxy
+    image: 'lucaslorentz/caddy-docker-proxy:2.8-alpine' # [!code --][!code focus]
+    build: # [!code ++][!code focus]
+      dockerfile_inline: | # [!code ++][!code focus]
+        FROM caddy:2.9-builder AS builder # [!code ++][!code focus]
+        RUN xcaddy build --with github.com/lucaslorentz/caddy-docker-proxy/v2 --with github.com/caddy-dns/route53 # [!code ++][!code focus]
+        FROM caddy:2.9-alpine # [!code ++][!code focus]
+        COPY --from=builder /usr/bin/caddy /usr/bin/caddy # [!code ++][!code focus]
+        CMD ["caddy", "docker-proxy"] # [!code ++][!code focus]
+    restart: unless-stopped
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - CADDY_DOCKER_POLLING_INTERVAL=5s
+      - CADDY_DOCKER_CADDYFILE_PATH=/dynamic/Caddyfile
+      - AWS_ACCESS_KEY_ID=<Access Key ID> # [!code ++][!code focus]
+      - AWS_SECRET_ACCESS_KEY=<Secret Access Key> # [!code ++][!code focus]
+      - AWS_REGION=<Region> # [!code ++][!code focus]
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    labels:
+      - coolify.managed=true
+      - coolify.proxy=true
+      - caddy.acme_dns=route53 # [!code ++][!code focus]
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/caddy/dynamic:/dynamic'
+      - '/data/coolify/proxy/caddy/config:/config'
+      - '/data/coolify/proxy/caddy/data:/data'
+```
+
+:::
+
+> For other DNS providers, find the module path at [github.com/caddy-dns](https://github.com/orgs/caddy-dns/repositories?utm_source=coolify.io), replace the `--with github.com/caddy-dns/<provider>` line in the Dockerfile, and set the appropriate environment variable and `caddy.acme_dns` label.
+
+Restart the proxy after saving. Caddy will build the image on first start and then use the DNS challenge to obtain and renew SSL certificates.
+
+## Troubleshooting
+
+**Certificate not issuing / DNS record not found**
+
+DNS propagation can be slow. You can add an explicit delay per-site by editing `/data/coolify/proxy/caddy/dynamic/Caddyfile` on your server:
+
+```
+your.domain.com {
+    tls {
+        dns hetzner {env.HETZNER_API_TOKEN}
+        propagation_delay 30s
+    }
+}
+```
+
+**Rate limits**
+
+Let's Encrypt enforces [rate limits](https://letsencrypt.org/docs/rate-limits/?utm_source=coolify.io). While testing, switch to the staging CA to avoid burning your quota. Add this label to the proxy container:
+
+```yaml
+- caddy.acme_ca=https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+Remove this label once everything works.
+
+**Wrong or missing DNS module**
+
+If Caddy starts but certificates fail with an `unknown provider` error, the DNS module was not included in the image build. Verify the `--with github.com/caddy-dns/<provider>` line in the `dockerfile_inline` matches your provider, then restart the proxy to trigger a rebuild.

--- a/docs/knowledge-base/proxy/traefik/dns-challenge.md
+++ b/docs/knowledge-base/proxy/traefik/dns-challenge.md
@@ -1,0 +1,311 @@
+---
+title: "DNS Challenge"
+description: "Switch Traefik from HTTP challenge to DNS challenge for ACME (Let's Encrypt) certificates — required for wildcard certs or servers without a public port 80."
+---
+
+# Switch Traefik to DNS Challenge
+
+By default, Coolify configures Traefik to obtain SSL certificates using the **HTTP challenge** (`httpChallenge`), which requires port 80 to be publicly reachable. There are two common reasons to switch to the **DNS challenge** (`dnsChallenge`) instead:
+
+- You want [wildcard SSL certificates](./wildcard-certs) (e.g., `*.example.com`) — these *require* DNS challenge.
+- Your server does not have a public port 80 (e.g., internal network, behind a firewall, or a Tailscale-only node).
+
+## How It Works
+
+Instead of proving domain ownership over HTTP, Traefik asks your DNS provider to create a temporary `TXT` record under `_acme-challenge.<your-domain>`. Let's Encrypt reads that record to confirm ownership, then issues the certificate. Traefik (via the [Lego](https://go-acme.github.io/lego/) library) handles the whole process automatically.
+
+## Prerequisites
+
+- A domain managed by a [supported DNS provider](https://go-acme.github.io/lego/dns/index.html#dns-providers).
+- An API token / key for that provider with permission to create and delete DNS records.
+
+::: tip Finding your provider's required variables
+Each provider needs different environment variables. Open the [Lego provider list](https://go-acme.github.io/lego/dns/index.html#dns-providers), click your provider, and note the required env vars listed at the top.
+:::
+
+## Configuration
+
+Go to **Servers → your server → Proxy** and replace the default Traefik configuration with the one below.
+
+The highlighted lines show exactly what changes from the default HTTP-challenge setup.
+
+:::code-group
+
+```yaml [Hetzner]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  traefik:
+    container_name: coolify-proxy
+    image: 'traefik:v3.6'
+    restart: unless-stopped
+    environment: # [!code focus]
+      - HETZNER_API_TOKEN=<Hetzner API Token> # [!code ++][!code focus]
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+      - '8080:8080'
+    healthcheck:
+      test: 'wget -qO- http://localhost:80/ping || exit 1'
+      interval: 4s
+      timeout: 2s
+      retries: 5
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/:/traefik'
+    command:
+      - '--ping=true'
+      - '--ping.entrypoint=http'
+      - '--api.dashboard=true'
+      - '--api.insecure=false'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https.address=:443'
+      - '--entrypoints.http.http.encodequerysemicolons=true'
+      - '--entryPoints.http.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http.encodequerysemicolons=true'
+      - '--entryPoints.https.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http3'
+      - '--providers.docker.exposedbydefault=false'
+      - '--providers.file.directory=/traefik/dynamic/'
+      - '--providers.file.watch=true'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=hetzner' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=0' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.storage=/traefik/acme.json'
+      - '--providers.docker=true'
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.entrypoints=http
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.services.traefik.loadbalancer.server.port=8080
+      - coolify.managed=true
+      - coolify.proxy=true
+```
+
+```yaml [Cloudflare]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  traefik:
+    container_name: coolify-proxy
+    image: 'traefik:v3.6'
+    restart: unless-stopped
+    environment: # [!code focus]
+      - CF_DNS_API_TOKEN=<Cloudflare API Token> # [!code ++][!code focus]
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+      - '8080:8080'
+    healthcheck:
+      test: 'wget -qO- http://localhost:80/ping || exit 1'
+      interval: 4s
+      timeout: 2s
+      retries: 5
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/:/traefik'
+    command:
+      - '--ping=true'
+      - '--ping.entrypoint=http'
+      - '--api.dashboard=true'
+      - '--api.insecure=false'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https.address=:443'
+      - '--entrypoints.http.http.encodequerysemicolons=true'
+      - '--entryPoints.http.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http.encodequerysemicolons=true'
+      - '--entryPoints.https.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http3'
+      - '--providers.docker.exposedbydefault=false'
+      - '--providers.file.directory=/traefik/dynamic/'
+      - '--providers.file.watch=true'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=0' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.storage=/traefik/acme.json'
+      - '--providers.docker=true'
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.entrypoints=http
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.services.traefik.loadbalancer.server.port=8080
+      - coolify.managed=true
+      - coolify.proxy=true
+```
+
+```yaml [Route53 (AWS)]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  traefik:
+    container_name: coolify-proxy
+    image: 'traefik:v3.6'
+    restart: unless-stopped
+    environment: # [!code focus]
+      - AWS_ACCESS_KEY_ID=<Access Key ID> # [!code ++][!code focus]
+      - AWS_SECRET_ACCESS_KEY=<Secret Access Key> # [!code ++][!code focus]
+      - AWS_REGION=<Region> # [!code ++][!code focus]
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+      - '8080:8080'
+    healthcheck:
+      test: 'wget -qO- http://localhost:80/ping || exit 1'
+      interval: 4s
+      timeout: 2s
+      retries: 5
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/:/traefik'
+    command:
+      - '--ping=true'
+      - '--ping.entrypoint=http'
+      - '--api.dashboard=true'
+      - '--api.insecure=false'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https.address=:443'
+      - '--entrypoints.http.http.encodequerysemicolons=true'
+      - '--entryPoints.http.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http.encodequerysemicolons=true'
+      - '--entryPoints.https.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http3'
+      - '--providers.docker.exposedbydefault=false'
+      - '--providers.file.directory=/traefik/dynamic/'
+      - '--providers.file.watch=true'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=route53' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=0' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.storage=/traefik/acme.json'
+      - '--providers.docker=true'
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.entrypoints=http
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.services.traefik.loadbalancer.server.port=8080
+      - coolify.managed=true
+      - coolify.proxy=true
+```
+
+```yaml [Hostinger]
+name: coolify-proxy
+networks:
+  coolify:
+    external: true
+services:
+  traefik:
+    container_name: coolify-proxy
+    image: 'traefik:v3.6'
+    restart: unless-stopped
+    environment: # [!code focus]
+      - HOSTINGER_API_TOKEN=<Hostinger API Token> # [!code ++][!code focus]
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+      - '8080:8080'
+    healthcheck:
+      test: 'wget -qO- http://localhost:80/ping || exit 1'
+      interval: 4s
+      timeout: 2s
+      retries: 5
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/:/traefik'
+    command:
+      - '--ping=true'
+      - '--ping.entrypoint=http'
+      - '--api.dashboard=true'
+      - '--api.insecure=false'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https.address=:443'
+      - '--entrypoints.http.http.encodequerysemicolons=true'
+      - '--entryPoints.http.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http.encodequerysemicolons=true'
+      - '--entryPoints.https.http2.maxConcurrentStreams=250'
+      - '--entrypoints.https.http3'
+      - '--providers.docker.exposedbydefault=false'
+      - '--providers.file.directory=/traefik/dynamic/'
+      - '--providers.file.watch=true'
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http' # [!code --][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=hostinger' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=0' # [!code ++][!code focus]
+      - '--certificatesresolvers.letsencrypt.acme.storage=/traefik/acme.json'
+      - '--providers.docker=true'
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.entrypoints=http
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.services.traefik.loadbalancer.server.port=8080
+      - coolify.managed=true
+      - coolify.proxy=true
+```
+
+:::
+
+> You can also use `env_file` instead of `environment` — create a `.env` file on the server and reference it. This is useful for keeping secrets out of the UI.
+
+> Change `--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=<name>` to match your provider's identifier from the [Lego provider list](https://go-acme.github.io/lego/dns/index.html#dns-providers).
+
+Restart the proxy after making these changes. Traefik will now use the DNS challenge to obtain and renew SSL certificates.
+
+## Troubleshooting
+
+**Certificate not issuing / DNS record not found**
+
+DNS propagation can be slow. If the challenge fails immediately, increase `delaybeforecheck` to give your provider time to propagate the TXT record:
+
+```
+- '--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=30'
+```
+
+**CNAME records interfering with challenge**
+
+If your domain uses CNAME delegation and challenges fail on renewal, set this environment variable to disable CNAME following:
+
+```yaml
+environment:
+  - LEGO_DISABLE_CNAME_SUPPORT=true
+```
+
+**Rate limits**
+
+Let's Encrypt enforces [rate limits](https://letsencrypt.org/docs/rate-limits/?utm_source=coolify.io). While testing, add the [staging CA](https://letsencrypt.org/docs/staging-environment/) flag to avoid burning your quota:
+
+```
+- '--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory'
+```
+
+Remove this flag once everything works.
+
+## Next Steps
+
+Now that Traefik uses the DNS challenge, you can issue [wildcard SSL certificates](./wildcard-certs) that cover all subdomains under your domain with a single certificate.


### PR DESCRIPTION
## Summary

- Adds a DNS challenge configuration guide for Traefik under `knowledge-base/proxy/traefik/dns-challenge.md`, covering Cloudflare, Hetzner, Hostinger, and Route53 with full annotated compose configs
- Adds a DNS challenge configuration guide for Caddy under `knowledge-base/proxy/caddy/dns-challenge.md`, covering the same providers — includes an inline `dockerfile_inline` build step since Caddy DNS modules must be compiled into the binary
- Both pages are linked from their respective nav sections in `config.mts`

## Test plan

- [ ] Verify that the outlined steps for the DNS challenge work on both Traefik and Caddy
- [x] Verify all code block annotations (`++`, `--`, focus) render correctly in dev server
- [x] Confirm tab switching works across all provider tabs in both guides
- [x] Check that internal links (wildcard certs, Lego provider list, caddy-dns org) resolve correctly
- [x] Verify nav entries appear in the correct sidebar sections under Traefik and Caddy