### PR TITLE
Missing Documentation Page for Imgcompress – PR Submitted

### DIFF
--- a/docs/services/imgcompress.md
+++ b/docs/services/imgcompress.md
@@ -1,0 +1,24 @@
+---
+title: Imgcompress
+description: "Run Imgcompress on Coolify for self-hosted image compression, format conversion across 70+ formats, and AI-powered background removal without uploading to third-party services."
+---
+
+# Imgcompress
+
+<ZoomableImage src="https://raw.githubusercontent.com/karimz1/imgcompress/refs/heads/main/images/web-ui/web-ui-upload-configure.webp" alt="Imgcompress web UI" />
+
+## What is Imgcompress?
+
+Imgcompress is a self-hosted image processing toolbox that handles compression, format conversion, and AI background removal in a single web interface. It supports over **70 input formats** (including PSD, HEIC, and RAW) and can output common formats or generate PDFs, all without sending files to external services.
+
+Key capabilities:
+
+- **Format conversion**: PSD, HEIC, RAW, and 70+ other formats converted in one place
+- **Image compression**: Reduce file sizes for photos and screenshots without quality loss
+- **PDF export**: Convert images to PDF directly from the browser
+- **AI background removal**: Remove backgrounds locally, keeping files private
+
+## Links
+
+- [The official website](https://imgcompress.karimzouine.com?utm_source=coolify.io)
+- [GitHub](https://github.com/karimz1/imgcompress?utm_source=coolify.io)


### PR DESCRIPTION
Hi,

I noticed that Imgcompress is listed on Coolify, which I really appreciate. Thank you for including it!

However, I wanted to flag a small issue: clicking on the tool currently leads to a blank or missing documentation page (see screenshots below). Since there's no content there yet, I went ahead and submitted a PR with a proper doc page to fix this.
Screenshots:

## Screenshoots 
<img width="1632" height="749" alt="image" src="https://github.com/user-attachments/assets/6053dc3d-d13e-4f7a-822e-72e2b524eb79" />

The resulting empty/missing page after clicking it.
<img width="1586" height="533" alt="image" src="https://github.com/user-attachments/assets/4625089c-b82f-4685-8a8f-b9e604def788" />

I'm the author of Imgcompress, so I'm happy to provide any additional information or make adjustments if needed. Let me know if there's anything else required to get the PR reviewed and merged.
Thanks again for featuring Imgcompress.

It's great to see open source tools getting visibility! 🙌
