### PR TITLE
docs(core): add manual basic auth configuration for Traefik and Caddy

### DIFF
--- a/content/docs/core/networking/proxy/caddy/basic-auth.mdx
+++ b/content/docs/core/networking/proxy/caddy/basic-auth.mdx
@@ -18,17 +18,18 @@ Choose the path that matches how the resource is deployed.
 <Tabs id="caddy-basic-auth-resource-type" items={['Standard application', 'Docker Compose or service']}>
 <Tab value="Standard application">
 
+### Automatic
 <Steps>
 <Step>
 
-### Open the application settings
+#### Open the application settings
 
 Open the application, select **Configuration > General**, then find **HTTP Basic Authentication**.
 
 </Step>
 <Step>
 
-### Add the credentials
+#### Add the credentials
 
 Enable **HTTP Basic Authentication**, then enter a **Username** and **Password**. Save the application settings.
 
@@ -37,17 +38,49 @@ Coolify hashes the password and adds a `caddy_<index>.basicauth.<username>` labe
 </Step>
 <Step>
 
-### Redeploy and verify
+#### Redeploy and verify
 
 Redeploy the application. Open its domain in a private browser window and confirm that the browser requests the new credentials before loading the application.
+
+</Step>
+</Steps>
+### Manual
+
+<Steps>
+<Step>
+#### Generate credentials
+    Generate a bcrypt hash with the Caddy CLI:
+
+    ```bash
+    caddy hash-password --plaintext '<password>'
+    ```
+</Step>
+<Step>
+#### Add the label
+Open the application **General** page, find **Container Labels**, then disable **Readonly labels**. Add one `basicauth` label matching the index Coolify already generated for you domain:
+
+```ini
+caddy_0.basicauth.<username>="<bcrypt-hash>" # [!code ++][!code focus]
+caddy_0.encode=zstd gzip
+caddy_0.handle.0_reverse_proxy={{upstreams 3000}}
+caddy_0.handle=/*
+caddy_0.header=-Server
+caddy_0.try_files={path} /index.html /index.php
+caddy_0=https://domain.com # [!code focus]
+caddy_ingress_network=coolify
+```
+</Step>
+<Step>
+
+    #### Redeploy and verify
+
+    Redeploy the application. Open its domain in a private browser window and confirm that the browser requests the new credentials before loading the application.
 
 </Step>
 </Steps>
 
 </Tab>
 <Tab value="Docker Compose or service">
-
-Add Caddy basic authentication manually when the resource does not expose the built-in setting.
 
 Generate a bcrypt hash with the Caddy CLI:
 

--- a/content/docs/core/networking/proxy/traefik/basic-auth.mdx
+++ b/content/docs/core/networking/proxy/traefik/basic-auth.mdx
@@ -18,19 +18,21 @@ Choose the path that matches how the resource is deployed.
 <Tabs id="traefik-basic-auth-resource-type" items={['Standard application', 'Docker Compose or service']}>
 <Tab value="Standard application">
 
+### Automatic
+
 Coolify hashes the password and generates the Traefik middleware when you enable the built-in setting.
 
 <Steps>
 <Step>
 
-### Open the application settings
+#### Open the application settings
 
 Open the application, select **Configuration > General**, then find **HTTP Basic Authentication**.
 
 </Step>
 <Step>
 
-### Add the credentials
+#### Add the credentials
 
 Enable **HTTP Basic Authentication**, then enter a **Username** and **Password**. Save the application settings.
 
@@ -39,12 +41,63 @@ Keep **Readonly labels** enabled so Coolify continues to generate the proxy labe
 </Step>
 <Step>
 
-### Redeploy and verify
+#### Redeploy and verify
 
 Redeploy the application. Open its domain in a private browser window and confirm that the browser requests the new credentials before loading the application.
 
 </Step>
 </Steps>
+
+### Manual
+
+<Steps>
+<Step>
+
+#### Generate credentials
+
+Generate a bcrypt credential with `htpasswd`. On Debian or Ubuntu, the command is provided by the `apache2-utils` package:
+
+```bash
+htpasswd -nbB <username> '<password>'
+```
+
+</Step>
+<Step>
+#### Add the labels
+    Open the application **General** page, find **Container Labels**, then disable **Readonly labels**. Basic authentication takes two labels: one that **defines** the middleware and one that **attaches** it to the HTTPS router.
+
+    ```ini
+    traefik.enable=true
+    traefik.http.middlewares.http-basic-auth.basicauth.users=<username>:<bcrypt-hash> # [!code ++][!code focus]
+    traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https
+    traefik.http.routers.http-0-<uuid>.entryPoints=http
+    traefik.http.routers.http-0-<uuid>.middlewares=redirect-to-https
+    traefik.http.routers.http-0-<uuid>.rule=Host(`domain.com`) && PathPrefix(`/`)
+    traefik.http.routers.http-0-<uuid>.service=http-0-<uuid>
+    traefik.http.routers.https-0-<uuid>.entryPoints=https
+    traefik.http.routers.https-0-<uuid>.middlewares=http-basic-auth # [!code ++][!code focus]
+    traefik.http.routers.https-0-<uuid>.rule=Host(`domain.com`) && PathPrefix(`/`) # [!code focus]
+    traefik.http.routers.https-0-<uuid>.service=https-0-<uuid>
+    traefik.http.routers.https-0-<uuid>.tls.certresolver=letsencrypt
+    traefik.http.routers.https-0-<uuid>.tls=true
+    traefik.http.services.http-0-<uuid>.loadbalancer.server.port=3000
+    traefik.http.services.https-0-<uuid>.loadbalancer.server.port=3000
+    ```
+    If the HTTPS router already lists middleware such as `gzip`, append `,http-basic-auth` to the existing comma-separated value instead of replacing it.
+
+    See [Custom middlewares](/core/networking/proxy/traefik/custom-middlewares) for what disabling **Readonly labels** makes you responsible for.
+</Step>
+<Step>
+
+    #### Redeploy and verify
+
+    Redeploy the application. Open its domain in a private browser window and confirm that the browser requests the new credentials before loading the application.
+
+</Step>
+</Steps>
+<Callout type="warning" title="Do not store the plaintext password in labels">
+    Use only the `htpasswd` output in the Traefik label. Store the plaintext password in a password manager and rotate it by replacing the hash and redeploying the resource.
+</Callout>
 
 </Tab>
 <Tab value="Docker Compose or service">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -491,14 +491,6 @@ html:not(.dark) .prose :where(thead tr) {
   box-shadow: 0 5px 12px rgb(94 62 216 / 0.22);
 }
 
-[data-mdx-tabs] [data-tab-value] > :where(h2, h3, h4):first-child {
-  height: 0;
-  margin: 0 !important;
-  overflow: hidden;
-  padding: 0 !important;
-  pointer-events: none;
-}
-
 [data-mdx-tabs] [data-tab-value] :where(p):has(+ table),
 [data-mdx-tabs] [data-tab-value] :where(p):has(+ div table) {
   margin-bottom: 0.375rem;


### PR DESCRIPTION
This PR was opened before the Fumadocs migration and targeted files that no longer exist. It has been rebuilt on top of the current `next`.

## What changed since the original PR

The migration deleted `docs/` and added its own rewritten Basic Authentication pages under `content/docs/core/networking/proxy/`. Those pages are good, so this PR no longer replaces them. It only restores the material that has no successor, and drops the parts of the original branch that turned out to be wrong.

## Summary

**Traefik — `## Configure the middleware manually`**
- Full container label set for a standard application, showing both the middleware definition and the router attachment
- The `http-basic-auth-<uuid>` naming convention Coolify's built-in setting uses
- How to read the resource identifier from existing labels, including the `https-0-<uuid>-<service-name>` form used by Compose services
- Warning against attaching the middleware to the HTTP router, which prompts for credentials before the HTTPS redirect
- `apache2-utils` / `httpd-tools` package names

**Caddy — `## Configure the middleware manually`**
- `caddy_<index>` semantics: each domain is its own site block, so a `basicauth` label protects only the index it names
- The two cases the built-in setting cannot cover: different credentials per domain, and several users on one domain
- Hash generation via the Caddy binary inside the running proxy, so no local Caddy install is needed

**Both** — `docker inspect` and `docker logs` added to the existing troubleshooting entries, alongside the existing **Proxy > Logs** pointers rather than replacing them.

**Custom middlewares** — an info callout linking to the Basic authentication page.

## Deliberately dropped from the original branch

Three claims did not survive checking against the Coolify source:

- **"Dollar signs must be escaped as `$$`"** — `is_container_label_escape_enabled` defaults to on and Coolify does this for you. Following the old text double-escapes and silently corrupts the hash. The current page already says this correctly and is left alone.
- **"bcrypt without the `$2a$` prefix is rejected"** — Coolify emits `$2y$` (`password_hash($pw, PASSWORD_BCRYPT, ...)`), as does `htpasswd -nbB`. Only `caddy hash-password` emits `$2a$`. All are valid.
- **`cat /config/caddy/Caddyfile`** — the proxy uses `CADDY_DOCKER_CADDYFILE_PATH=/dynamic/Caddyfile`; `/config` is Caddy's autosave directory. Replaced with `docker logs`.

The sidebar reorder from the original branch is also dropped: `caddy/meta.json` places `basic-auth` at the same position, so reordering only Traefik would desync the two proxy sections.

## Verification

Claims checked against `coollabsio/coolify` — `bootstrap/helpers/docker.php:441,461,507-511` and `bootstrap/helpers/proxy.php:366`.

`bun run types:check` and `bun run build` both pass; all three pages prerender.