### PR TITLE
docs(storage): clarify file mount prerequisites

### DIFF
--- a/content/docs/knowledge-base/docker/compose.mdx
+++ b/content/docs/knowledge-base/docker/compose.mdx
@@ -255,6 +255,14 @@ Support for Magic Environment Variables in Compose files based on Git sources re
 
 You can predefine storage normally in your compose file, but there are a few extra options that you can set to tell Coolify what to do with the storage.
 
+<Callout type="warn" title="File mount prerequisites">
+
+When you bind mount a file, the source file must already exist on the server or be created by Coolify with `content:`. If the file is stored in your Git repository, enable **Preserve Repository During Deployment** in the application settings so the repository files remain available during the Docker Compose deployment.
+
+If the source file is missing, Docker can create a directory at that path instead. This often causes deployment errors such as `not a directory: unknown`.
+
+</Callout>
+
 ### Create an empty directory
 
 ```yaml
@@ -312,6 +320,14 @@ configs:
         ALTER USER authenticator WITH PASSWORD :'pgpass';
         ALTER USER pgbouncer WITH PASSWORD :'pgpass';
 ```
+
+### Troubleshooting file mounts
+
+If a deployment fails with `not a directory: unknown`, check the bind mount source path:
+
+- For generated configuration files, add `content:` to the bind mount so Coolify creates the file.
+- For files committed to your Git repository, enable **Preserve Repository During Deployment**.
+- For host files outside the repository, SSH into the server and verify that the source path exists as a file, not a directory.
 
 ## Exclude from healthchecks
 

--- a/content/docs/knowledge-base/persistent-storage.mdx
+++ b/content/docs/knowledge-base/persistent-storage.mdx
@@ -46,6 +46,14 @@ To create a bind mount, you need to define:
 - `Source Path` from the host system. **No docker volume created in this case.**
 - `Destination Path` where the volume will be mounted inside the container.
 
+<Callout type="warn" title="File bind mounts">
+
+If the bind mount source is a file, make sure that file already exists on the server before deployment. If Docker receives a missing file path, it can create a directory at that path and the container may fail with errors like `not a directory: unknown`.
+
+For Docker Compose applications that mount files from the Git repository, enable **Preserve Repository During Deployment** in the application settings. For generated configuration files, use the Docker Compose `content:` option described in [Docker Compose storage](/knowledge-base/docker/compose#storage).
+
+</Callout>
+
 
 <Callout type="warn" title="Caution">
 


### PR DESCRIPTION
## Changes
- Add file bind mount prerequisites to the Docker Compose storage docs.
- Add troubleshooting guidance for `not a directory: unknown` mount failures.
- Add a matching Persistent Storage warning for file bind mounts.

## Issue
- Closes #347

## Verification
- Checked the Coolify UI label for **Preserve Repository During Deployment** in the application settings.
- Checked Coolify deployment code paths that use the preserve repository setting for Docker Compose deployments.

## Testing
- `git diff --check`
- Not run: local docs build/typecheck, because this checkout has no `bun` command or `node_modules` installed.