### PR TITLE
docs: fix stray backtick in Supabase ports snippet

### DIFF
--- a/content/docs/services/supabase.mdx
+++ b/content/docs/services/supabase.mdx
@@ -42,7 +42,7 @@ Go to the **General** tab then **Edit Compose File**
 Then add this line:
 ```yaml
 ports:
-      - ${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}`
+      - ${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}
 ```
 To
 


### PR DESCRIPTION
Removes a stray backtick after the ports mapping in the Supabase "Public Port Access" docker-compose snippet, which made the YAML block invalid.