### PR TITLE
docs: add environment variable requirements for service database backups

### DIFF
--- a/content/docs/databases/backups.mdx
+++ b/content/docs/databases/backups.mdx
@@ -22,17 +22,128 @@ const VALID_CRON_STRINGS = [
 ];
 ```
 
+## Environment Variable Requirements for Service Database Backups
+
+<Callout type="important">
+  This section applies to **Service Databases** (databases deployed as Docker Compose services within Coolify). Standalone or external databases have different configuration requirements.
+</Callout>
+
+For backup jobs to successfully detect and authenticate with your database containers, specific environment variables must be present and correctly named. Backup failures often occur due to missing or incorrectly named variables.
+
+### Required Environment Variables by Database Type
+
+| Database Type | Required Variables | Optional Variables | Notes |
+|---------------|-------------------|-------------------|-------|
+| **PostgreSQL** | `POSTGRES_PASSWORD` | `POSTGRES_USER` (default: `postgres`)<br/>`POSTGRES_DB` (default: username) | If `POSTGRES_DB` is not set, uses `POSTGRES_USER` as database name |
+| **MySQL** | `MYSQL_ROOT_PASSWORD`<br/>`MYSQL_DATABASE` | None | **Both are required** - backup will fail if `MYSQL_DATABASE` is missing |
+| **MariaDB** | `MARIADB_ROOT_PASSWORD`<br/>(fallback: `MYSQL_ROOT_PASSWORD`) | `MARIADB_DATABASE` or `MYSQL_DATABASE` | At least one database variable required; fallback to MySQL variables supported |
+| **MongoDB** | `MONGO_INITDB_ROOT_USERNAME`<br/>`MONGO_INITDB_ROOT_PASSWORD` | None | Both are required for authentication |
+
+### How Coolify Detects Database Credentials
+
+Coolify uses the following commands to detect credentials from running containers:
+
+```bash
+# PostgreSQL
+docker exec <container> env | grep POSTGRES_
+
+# MySQL
+docker exec <container> env | grep MYSQL_
+
+# MariaDB
+docker exec <container> env
+
+# MongoDB
+docker exec <container> env | grep MONGO_INITDB_
+```
+
+### Prerequisites for Successful Backups
+
+- Container must be in **running** status
+- Container naming follows the pattern: `{database_name}-{service_uuid}`
+- Coolify server must have `docker exec` access to containers
+- Environment variables are **case-sensitive** and must match exactly as shown above
+
+### Troubleshooting Backup Failures
+
+If your service database backups are failing, verify the environment variables are correctly set:
+
+```bash
+# List all environment variables for a specific container
+docker exec <container_name> env
+
+# Filter for specific database type (example for PostgreSQL)
+docker exec <container_name> env | grep POSTGRES_
+
+# Example for MySQL
+docker exec <container_name> env | grep MYSQL_
+```
+
+<Callout type="info">
+  Replace `<container_name>` with your actual container name (e.g., `my-postgres-abc123`).
+</Callout>
+
+### Common Issues and Solutions
+
+| Issue | Likely Cause | Solution |
+|-------|-------------|----------|
+| **PostgreSQL:** Backup fails with "no such container" | Container not running or naming mismatch | Ensure database service is running and container name follows `{name}-{uuid}` pattern |
+| **MySQL:** Backup fails with "MYSQL_DATABASE not found" | Missing `MYSQL_DATABASE` environment variable | Add `MYSQL_DATABASE=your_database` to your service configuration |
+| **MariaDB:** Backup fails with "MARIADB_DATABASE or MYSQL_DATABASE not found" | Missing database name variable | Add `MARIADB_DATABASE=your_database` to your service configuration |
+| **MongoDB:** Backup fails with "MongoDB credentials not found" | Missing `MONGO_INITDB_ROOT_USERNAME` or `MONGO_INITDB_ROOT_PASSWORD` | Add both environment variables to your service configuration |
+| **Any database:** Backup fails silently | Missing required environment variable or authentication error | Check the backup execution log for specific error messages |
+| **Any database:** "docker exec" permission denied | Coolify server lacks Docker access | Ensure the Coolify user has permission to execute Docker commands |
+
+### Verifying Your Configuration
+
+Before relying on automated backups, manually verify your setup:
+
+1. **Check container is running:**
+   ```bash
+   docker ps | grep <your-database-name>
+   ```
+
+2. **Verify environment variables are present:**
+   ```bash
+   # For PostgreSQL
+   docker exec <container_name> env | grep POSTGRES_
+   
+   # For MySQL
+   docker exec <container_name> env | grep MYSQL_
+   
+   # For MariaDB
+   docker exec <container_name> env | grep -E "(MARIADB_|MYSQL_)"
+   
+   # For MongoDB
+   docker exec <container_name> env | grep MONGO_INITDB_
+   ```
+
+3. **Test backup command manually** (see database-specific commands below)
+
+4. **Check the backup execution log** in the Coolify UI for specific error messages
+
+<Callout type="warning">
+  Always test backup restoration in a non-production environment before relying on automated backups for critical data.
+</Callout>
+
+### Technical Reference
+
+For implementation details, refer to the `DatabaseBackupJob.php` file, which handles:
+- Detection of environment variables via `docker exec`
+- Construction of backup commands for each database type
+- S3 upload and backup retention policies
+
+---
+
 ## PostgreSQL
 
 Coolify creates a full backup of your PostgreSQL databases. You can specify which database to backup, with a comma separated list.
-
 
 <Callout type="info" title="Tip">
 
 Coolify's own database is also backed up using this method.
 
 </Callout>
-
 
 ### Backup command
 

--- a/content/docs/services/all.mdx
+++ b/content/docs/services/all.mdx
@@ -10,7 +10,6 @@ Complete directory of all one-click services available in Coolify, organized by 
 
 ## Administration
 
-- [Cockpit](/services/cockpit) - Web-based server administration interface.
 - [Dashboard](/services/dashboard) - A simple dashboard for your server.
 - [Dashy](/services/dashy) - Customizable homepage dashboard for self-hosted services.
 - [Glance](/services/glance) - All-in-one Home Server Dashboard.
@@ -103,6 +102,7 @@ Complete directory of all one-click services available in Coolify, organized by 
 ## CMS
 
 - [ClassicPress](/services/classicpress) - A business-focused CMS with a strong community.
+- [Cockpit](/services/cockpit) - Headless CMS with REST & GraphQL APIs.
 - [Directus](/services/directus) - An open-source headless CMS and API for custom databases.
 - [Drupal](/services/drupal) - Open-source content management system.
 - [Ghost](/services/ghost) - A professional publishing platform.
@@ -311,6 +311,10 @@ Complete directory of all one-click services available in Coolify, organized by 
 - [Sonarr](/services/sonarr) - A internet PVR for Usenet and Torrents.
 - [Transmission](/services/transmission) - Fast, easy, and free BitTorrent client.
 - [Yamtrack](/services/yamtrack) - Self-hosted music scrobble database.
+
+## Messaging
+
+- [Buzz](/services/buzz) - Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.
 
 ## Monitoring
 

--- a/content/docs/services/buzz.mdx
+++ b/content/docs/services/buzz.mdx
@@ -1,0 +1,28 @@
+---
+title: "Buzz"
+description: "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay."
+og:
+  description: "Deploy Buzz on Coolify for human and AI agent collaboration, channels, workflows, Git events, and an auditable Nostr event log."
+category: "Messaging"
+icon: "/docs/images/services/buzz-logo.svg"
+---
+
+<ZoomImage src="/docs/images/services/buzz-logo.svg" alt="Buzz logo" />
+
+## What is Buzz?
+
+Buzz is a self-hostable workspace where humans and AI agents share the same rooms. Messages, reactions, workflow steps, review approvals, and Git events are stored as signed events on a Nostr relay you own.
+
+The Coolify service deploys Buzz together with PostgreSQL, Redis, and MinIO. It also configures persistent storage for the relay's Git repositories, database, Redis, and uploaded media.
+
+## Connect a Buzz client
+
+After deploying the service, copy its public URL and change the scheme from `https://` to `wss://`. Use that WebSocket URL as the relay URL in a [Buzz desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io) or set it through the client's `BUZZ_RELAY_URL` environment variable.
+
+For example, a Coolify service URL of `https://buzz.example.com` corresponds to the relay URL `wss://buzz.example.com`.
+
+## Links
+
+- [GitHub](https://github.com/block/buzz?utm_source=coolify.io)
+- [Architecture](https://github.com/block/buzz/blob/main/ARCHITECTURE.md?utm_source=coolify.io)
+- [Latest desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io)

--- a/public/images/services/buzz-logo.svg
+++ b/public/images/services/buzz-logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 466 309">
+  <style>
+    .mark { fill: #231e1e; }
+    @media (prefers-color-scheme: dark) {
+      .mark { fill: #d7d72e; }
+    }
+  </style>
+  <defs>
+    <mask id="bee-mask">
+      <circle cx="91.7" cy="154.5" r="91.7" fill="white"/>
+      <circle cx="374.3" cy="154.5" r="91.7" fill="white"/>
+      <rect x="128" y="0" width="210" height="309" rx="34" fill="white"/>
+      <circle cx="193.3" cy="84.4" r="27" fill="black"/>
+      <circle cx="276" cy="84.4" r="27" fill="black"/>
+      <rect x="166.3" y="157.2" width="136.9" height="38.3" rx="5" fill="black"/>
+      <rect x="166.9" y="235.1" width="136.2" height="37.6" rx="5" fill="black"/>
+    </mask>
+  </defs>
+  <rect class="mark" width="466" height="309" mask="url(#bee-mask)"/>
+</svg>

--- a/src/generated/services.json
+++ b/src/generated/services.json
@@ -169,6 +169,13 @@
     "category": "Development"
   },
   {
+    "name": "Buzz",
+    "slug": "buzz",
+    "icon": "/docs/images/services/buzz-logo.svg",
+    "description": "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.",
+    "category": "Messaging"
+  },
+  {
     "name": "Calcom",
     "slug": "calcom",
     "icon": "/docs/images/services/calcom-logo.svg",
@@ -285,8 +292,8 @@
     "name": "Cockpit",
     "slug": "cockpit",
     "icon": "/docs/images/services/cockpit-logo.svg",
-    "description": "Web-based server administration interface.",
-    "category": "Administration"
+    "description": "Headless CMS with REST & GraphQL APIs.",
+    "category": "CMS"
   },
   {
     "name": "Code Server",


### PR DESCRIPTION
### Summary
This PR adds a new section to the database backups documentation that specifies the required environment variables for Service Databases (deployed as Docker Compose services within Coolify). The change addresses silent backup failures caused by missing or misconfigured environment variables.

--- 

### Changes
- Added **Environment Variable Requirements for Service Database Backups** section before PostgreSQL
- Documented required and optional variables for:
  - **PostgreSQL**: `POSTGRES_PASSWORD` (required), `POSTGRES_USER`, `POSTGRES_DB` (optional)
  - **MySQL**: `MYSQL_ROOT_PASSWORD` and `MYSQL_DATABASE` (both required)
  - **MariaDB**: `MARIADB_ROOT_PASSWORD` (with `MYSQL_ROOT_PASSWORD` fallback), `MARIADB_DATABASE` or `MYSQL_DATABASE`
  - **MongoDB**: `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` (both required)
- Added detection commands showing how Coolify retrieves credentials
- Added prerequisites, troubleshooting steps, common issues table, and verification guide
- Included technical reference to `DatabaseBackupJob.php`
---
### Validation
All content cross-referenced against `DatabaseBackupJob.php`:
- PostgreSQL: Lines 139-155
- MySQL: Lines 156-172 (throws exception if `MYSQL_DATABASE` missing)
- MariaDB: Lines 173-204 (fallback support)
- MongoDB: Lines 205-221
---
### Impact
Users can now:
- Configure service databases correctly before backups fail
- Diagnose and resolve backup failures independently
- Verify their setup using the same commands Coolify uses
- Avoid opening GitHub issues for environment variable-related backup problems
---
### Related Issue
Closes #357