### PR TITLE
fix(seo): empty H1s, short service metas, leftover redirects, API sitemap

### DIFF
--- a/content/docs/databases/index.mdx
+++ b/content/docs/databases/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Databases
 description: Deploy databases on Coolify with one-click setup for PostgreSQL, MySQL, MariaDB, MongoDB, Redis, KeyDB, DragonFly, and ClickHouse.
 ---
 

--- a/content/docs/get-started/cloud.mdx
+++ b/content/docs/get-started/cloud.mdx
@@ -7,7 +7,7 @@ description: Coolify Cloud is a fully managed PaaS service with zero maintenance
 
 <br />
 
-[Coolify Cloud](https://coolify.io/pricing/) is our managed, paid service (maintained by [Andras](https://x.com/heyandras), Coolify’s Founder) that runs the Coolify on our infrastructure, so you don’t need to allocate CPU, RAM, or disk for Coolify itself.
+[Coolify Cloud](https://coolify.io/pricing) is our managed, paid service (maintained by [Andras](https://x.com/heyandras), Coolify’s Founder) that runs the Coolify on our infrastructure, so you don’t need to allocate CPU, RAM, or disk for Coolify itself.
 
 You still bring your own servers (VPS, Raspberry Pi, EC2, etc.) and connect them via SSH, then deploy apps, databases, and services exactly as you would with a self-hosted instance.
 

--- a/content/docs/get-started/downgrade.mdx
+++ b/content/docs/get-started/downgrade.mdx
@@ -7,7 +7,7 @@ description: Downgrade self-hosted Coolify to previous versions by disabling aut
 
 <br />
 
-If you're using [Coolify Cloud](https://coolify.io/pricing/), the Coolify team handles all updates so you **cannot** downgrade the version of Coolify. If you are facing any issues, please contact [support](/get-started/support).
+If you're using [Coolify Cloud](https://coolify.io/pricing), the Coolify team handles all updates so you **cannot** downgrade the version of Coolify. If you are facing any issues, please contact [support](/get-started/support).
 
 For those who **self-host** Coolify, you can easily downgrade to the previous version. Follow the steps below to perform a downgrade on to a previous version.
 

--- a/content/docs/get-started/uninstallation.mdx
+++ b/content/docs/get-started/uninstallation.mdx
@@ -7,7 +7,7 @@ description: Completely remove Coolify from your self-hosted server by stopping 
 
 <br />
 
-If you're using [Coolify Cloud](https://coolify.io/pricing/), you don't need to uninstall Coolify since the Coolify Team manages everything on their servers.
+If you're using [Coolify Cloud](https://coolify.io/pricing), you don't need to uninstall Coolify since the Coolify Team manages everything on their servers.
 
 To stop using Coolify Cloud, simply visit the [Billing page](https://app.coolify.io/subscription/) and cancel your subscription.
 

--- a/content/docs/get-started/upgrade.mdx
+++ b/content/docs/get-started/upgrade.mdx
@@ -7,7 +7,7 @@ description: Upgrade self-hosted Coolify automatically, semi-automatically with 
 
 <br />
 
-If you're using [Coolify Cloud](https://coolify.io/pricing/), the Coolify team handles all updates so you don’t need to worry about them.
+If you're using [Coolify Cloud](https://coolify.io/pricing), the Coolify team handles all updates so you don’t need to worry about them.
 
 For those who **self-host** Coolify, there are three ways to upgrade your instance:
 

--- a/content/docs/get-started/usage.mdx
+++ b/content/docs/get-started/usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Usage
+title: Cloud vs Self-Hosted
 description: Compare Coolify Cloud managed service starting at $5/month versus free self-hosted deployment with maintenance, support, and backup differences.
 ---
 

--- a/content/docs/knowledge-base/destinations/index.mdx
+++ b/content/docs/knowledge-base/destinations/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: "Destinations"
 description: "Manage Docker network destinations in Coolify for isolated deployment environments supporting standalone Docker and Swarm cluster configurations."
 ---
 

--- a/content/docs/knowledge-base/s3/introduction.mdx
+++ b/content/docs/knowledge-base/s3/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: "S3 Storage"
 description: "Configure S3-compatible storage for Coolify backups including AWS, DigitalOcean Spaces, MinIO, Cloudflare R2, Supabase Storage, Backblaze B2, and Scaleway Object Storage."
 ---
 

--- a/content/docs/knowledge-base/server/firewall.mdx
+++ b/content/docs/knowledge-base/server/firewall.mdx
@@ -6,7 +6,7 @@ description: "Configure firewall ports for Coolify including SSH, HTTP/HTTPS, da
 # Firewall
 Coolify requires specific network ports to be open in order to function properly across various environments. These ports enable web access, SSH connections, terminal sessions, and real-time communication. 
 
-The required ports may vary slightly depending on whether you're using a self-hosted setup or the managed version ([Coolify Cloud](https://coolify.io/pricing/)).
+The required ports may vary slightly depending on whether you're using a self-hosted setup or the managed version ([Coolify Cloud](https://coolify.io/pricing)).
 
 
 ## Coolify Self-hosted

--- a/content/docs/knowledge-base/server/introduction.mdx
+++ b/content/docs/knowledge-base/server/introduction.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Introduction"
+title: "Servers"
 description: "Connect localhost and remote Linux servers to Coolify with SSH authentication, Docker Engine, wildcard domains, and Traefik proxy setup."
 ---
-# Introduction
+# Servers
 No matter what type of server you have (localhost or remote), you need the following requirements.
 - Connectivity
   - SSH connectivity between Coolify and the server with SSH key authentication.

--- a/content/docs/services/all.mdx
+++ b/content/docs/services/all.mdx
@@ -10,7 +10,6 @@ Complete directory of all one-click services available in Coolify, organized by 
 
 ## Administration
 
-- [Cockpit](/services/cockpit) - Web-based server administration interface.
 - [Dashboard](/services/dashboard) - A simple dashboard for your server.
 - [Dashy](/services/dashy) - Customizable homepage dashboard for self-hosted services.
 - [Glance](/services/glance) - All-in-one Home Server Dashboard.
@@ -103,6 +102,7 @@ Complete directory of all one-click services available in Coolify, organized by 
 ## CMS
 
 - [ClassicPress](/services/classicpress) - A business-focused CMS with a strong community.
+- [Cockpit](/services/cockpit) - Headless CMS with REST & GraphQL APIs.
 - [Directus](/services/directus) - An open-source headless CMS and API for custom databases.
 - [Drupal](/services/drupal) - Open-source content management system.
 - [Ghost](/services/ghost) - A professional publishing platform.
@@ -311,6 +311,10 @@ Complete directory of all one-click services available in Coolify, organized by 
 - [Sonarr](/services/sonarr) - A internet PVR for Usenet and Torrents.
 - [Transmission](/services/transmission) - Fast, easy, and free BitTorrent client.
 - [Yamtrack](/services/yamtrack) - Self-hosted music scrobble database.
+
+## Messaging
+
+- [Buzz](/services/buzz) - Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.
 
 ## Monitoring
 

--- a/content/docs/services/buzz.mdx
+++ b/content/docs/services/buzz.mdx
@@ -1,0 +1,28 @@
+---
+title: "Buzz"
+description: "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay."
+og:
+  description: "Deploy Buzz on Coolify for human and AI agent collaboration, channels, workflows, Git events, and an auditable Nostr event log."
+category: "Messaging"
+icon: "/docs/images/services/buzz-logo.svg"
+---
+
+<ZoomImage src="/docs/images/services/buzz-logo.svg" alt="Buzz logo" />
+
+## What is Buzz?
+
+Buzz is a self-hostable workspace where humans and AI agents share the same rooms. Messages, reactions, workflow steps, review approvals, and Git events are stored as signed events on a Nostr relay you own.
+
+The Coolify service deploys Buzz together with PostgreSQL, Redis, and MinIO. It also configures persistent storage for the relay's Git repositories, database, Redis, and uploaded media.
+
+## Connect a Buzz client
+
+After deploying the service, copy its public URL and change the scheme from `https://` to `wss://`. Use that WebSocket URL as the relay URL in a [Buzz desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io) or set it through the client's `BUZZ_RELAY_URL` environment variable.
+
+For example, a Coolify service URL of `https://buzz.example.com` corresponds to the relay URL `wss://buzz.example.com`.
+
+## Links
+
+- [GitHub](https://github.com/block/buzz?utm_source=coolify.io)
+- [Architecture](https://github.com/block/buzz/blob/main/ARCHITECTURE.md?utm_source=coolify.io)
+- [Latest desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io)

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -65,12 +65,16 @@ http {
             try_files $uri/index.html $uri.html $uri @docs_soft_404;
         }
 
+        location = /docs/404.html {
+            try_files /docs/404.html /404.html =404;
+        }
+
         location @docs_soft_404 {
-            return 302 /docs;
+            return 404;
         }
 
         # a folder without index.html raises 403 in this setup
-        error_page 403 =302 /docs;
+        error_page 403 404 /docs/404.html;
         location = /favicon.ico {
             rewrite ^/favicon.ico$ /docs/brand/favicon.ico;
             access_log off;

--- a/nginx/redirects.conf
+++ b/nginx/redirects.conf
@@ -96,9 +96,10 @@ location = /knowledge-base/contribute/service { return 301 /docs/get-started/con
 location = /knowledge-base/contribute/documentation { return 301 /docs/get-started/contribute/documentation; }
 
 # Redirects for the pages we removed on the new docs -> New Paths
-location = /screenshots { return 301 /docs/get-started/screenshots; }
-location = /videos { return 301 /docs/get-started/videos; }
-location = /contact { return 301 /docs/get-started/support; }
+# Optional /docs prefix and trailing slash so leftover links 301 to the article, not /docs.
+location ~ ^/(?:docs/)?screenshots/?$ { return 301 /docs/get-started/screenshots; }
+location ~ ^/(?:docs/)?videos/?$ { return 301 /docs/get-started/videos; }
+location ~ ^/(?:docs/)?contact/?$ { return 301 /docs/get-started/support; }
 
 # Redirects for API pages
 location ~ ^/docs/api-reference/api/?$ { return 301 /docs/api-reference/authorization; }
@@ -108,13 +109,14 @@ location ~ ^/api-reference/api/operations/deploy-by-tag-or-uuid/?$ { return 301 
 location = /api/operations/deploy-by-tag-or-uuid { return 301 /docs/api-reference/authorization; }
 
 # Redirects for Docs Restructure
-location = /what-is-coolify { return 301 /docs/get-started/introduction; }
-location = /cloud-vs-selfhost { return 301 /docs/get-started/usage; }
-location = /installation { return 301 /docs/get-started/installation; }
-location = /upgrade { return 301 /docs/get-started/upgrade; }
-location = /downgrade { return 301 /docs/get-started/downgrade; }
-location = /uninstallation { return 301 /docs/get-started/uninstallation; }
-location = /support { return 301 /docs/get-started/support; }
+location ~ ^/(?:docs/)?what-is-coolify/?$ { return 301 /docs/get-started/introduction; }
+location ~ ^/(?:docs/)?cloud-vs-selfhost/?$ { return 301 /docs/get-started/usage; }
+location ~ ^/(?:docs/)?installation/?$ { return 301 /docs/get-started/installation; }
+location ~ ^/(?:docs/)?upgrade/?$ { return 301 /docs/get-started/upgrade; }
+location ~ ^/(?:docs/)?downgrade/?$ { return 301 /docs/get-started/downgrade; }
+location ~ ^/(?:docs/)?uninstallation/?$ { return 301 /docs/get-started/uninstallation; }
+location ~ ^/(?:docs/)?support/?$ { return 301 /docs/get-started/support; }
+location ~ ^/(?:docs/)?cloud/?$ { return 301 /docs/get-started/cloud; }
 
 location = /knowledge-base/common-issues/cloudflare { return 301 /docs/get-started/support; }
 location = /knowledge-base/proxy/traefik/healthchecks { return 301 /docs/knowledge-base/health-checks; }
@@ -152,3 +154,7 @@ location = /knowledge-base/git/gitea/integration { return 301 /docs/applications
 
 # Redirects for common CI/CD URL patterns (based on access logs)
 location = /integration/cicd { return 301 /docs/applications/ci-cd; }
+
+# Trailing-slash leftovers that are not a specific article should canonicalize
+# to the no-slash path. Unknown no-slash paths then 404 instead of 302 to /docs.
+location ~ ^/docs/(.+)/$ { return 301 /docs/$1; }

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page not found | Coolify Docs</title>
+    <meta name="description" content="This Coolify documentation page does not exist." />
+    <meta name="robots" content="noindex" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #07070a;
+        --fg: #f8fafc;
+        --muted: #94a3b8;
+        --accent: #6b16ed;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--fg);
+      }
+      main {
+        max-width: 36rem;
+        padding: 2rem;
+        text-align: center;
+      }
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 2rem;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+      a {
+        color: #fff;
+        background: var(--accent);
+        text-decoration: none;
+        border-radius: 0.5rem;
+        padding: 0.7rem 1.1rem;
+        font-weight: 600;
+        display: inline-block;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p>This documentation URL does not exist. It may have been moved or the link is outdated.</p>
+      <a href="/docs">Back to Coolify Docs</a>
+    </main>
+  </body>
+</html>

--- a/public/images/services/buzz-logo.svg
+++ b/public/images/services/buzz-logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 466 309">
+  <style>
+    .mark { fill: #231e1e; }
+    @media (prefers-color-scheme: dark) {
+      .mark { fill: #d7d72e; }
+    }
+  </style>
+  <defs>
+    <mask id="bee-mask">
+      <circle cx="91.7" cy="154.5" r="91.7" fill="white"/>
+      <circle cx="374.3" cy="154.5" r="91.7" fill="white"/>
+      <rect x="128" y="0" width="210" height="309" rx="34" fill="white"/>
+      <circle cx="193.3" cy="84.4" r="27" fill="black"/>
+      <circle cx="276" cy="84.4" r="27" fill="black"/>
+      <rect x="166.3" y="157.2" width="136.9" height="38.3" rx="5" fill="black"/>
+      <rect x="166.9" y="235.1" width="136.2" height="37.6" rx="5" fill="black"/>
+    </mask>
+  </defs>
+  <rect class="mark" width="466" height="309" mask="url(#bee-mask)"/>
+</svg>

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -246,14 +246,56 @@ function shouldIgnoreUrl(url) {
 }
 
 function parseRedirects(contents) {
-  return Array.from(
-    contents.matchAll(/location\s+=\s+(\S+)\s+\{\s+return\s+(30[1278])\s+([^;\s]+)\s*;\s+\}/g),
-    (match) => ({
-      from: match[1],
-      status: Number(match[2]),
-      to: match[3],
-    }),
-  );
+  const redirects = [];
+  const seen = new Set();
+
+  const add = (from, status, to) => {
+    const key = `${from}=>${to}`;
+    if (!from || seen.has(key)) return;
+    seen.add(key);
+    redirects.push({ from, status, to });
+  };
+
+  for (const match of contents.matchAll(/location\s+=\s+(\S+)\s+\{\s+return\s+(30[1278])\s+([^;\s]+)\s*;\s+\}/g)) {
+    add(match[1], Number(match[2]), match[3]);
+  }
+
+  for (const match of contents.matchAll(/location\s+~\s+\^(.+?)\$\s+\{\s+return\s+(30[1278])\s+([^;\s]+)\s*;\s+\}/g)) {
+    const status = Number(match[2]);
+    const to = match[3];
+    for (const from of expandRedirectPattern(match[1])) {
+      add(from, status, to);
+    }
+  }
+
+  return redirects;
+}
+
+function expandRedirectPattern(pattern) {
+  const paths = new Set();
+
+  const expand = (current) => {
+    const optionalGroup = current.match(/^(.*)(?:\(\?:([^)]+)\)\?)(.*)$/);
+    if (optionalGroup && optionalGroup[2] && !optionalGroup[2].includes('(')) {
+      expand(`${optionalGroup[1]}${optionalGroup[3]}`);
+      expand(`${optionalGroup[1]}${optionalGroup[2]}${optionalGroup[3]}`);
+      return;
+    }
+
+    const optionalSlash = current.match(/^(.*)\/\?(.*)$/);
+    if (optionalSlash) {
+      expand(`${optionalSlash[1]}${optionalSlash[2]}`);
+      expand(`${optionalSlash[1]}/${optionalSlash[2]}`);
+      return;
+    }
+
+    if (/[()[\]{}.*+]/.test(current)) return;
+
+    paths.add(current.startsWith('/') ? current : `/${current}`);
+  };
+
+  expand(pattern);
+  return [...paths];
 }
 
 async function findMdxFiles(directory) {
@@ -281,6 +323,10 @@ function sourceFileToPageUrl(file) {
 
 function docsUrlForPath(pathname) {
   const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  if (docsPathPrefix !== '/' && (path === docsPathPrefix || path.startsWith(`${docsPathPrefix}/`))) {
+    return new URL(path, docsOrigin).href;
+  }
+
   const prefix = docsPathPrefix === '/' ? '' : docsPathPrefix;
   return new URL(`${prefix}${path}`, docsOrigin).href;
 }

--- a/scripts/generate-fumadocs-content.mjs
+++ b/scripts/generate-fumadocs-content.mjs
@@ -77,7 +77,6 @@ const sidebarMetas = {
       'vuejs',
       'nuxt',
       'svelte-kit',
-      'vitepress',
       '---Build Packs---',
       'build-packs',
       '---CI/CD---',

--- a/scripts/lib/content.ts
+++ b/scripts/lib/content.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { extname, join, relative, resolve, sep } from 'node:path';
 import matter from 'gray-matter';
+import { frontmatterOgDescription, resolveSeoDescription } from '../../src/lib/seo';
 import { site } from './site';
 import { currentDirFromMetaUrl } from './runtime-path';
 
@@ -90,6 +91,54 @@ function buildRoute(relativeFilePath: string) {
   };
 }
 
+export async function getOpenApiEntries(): Promise<DocEntry[]> {
+  const { loader, multiple, source: createSource } = await import('fumadocs-core/source');
+  const { openapiPlugin, openapiSource } = await import('fumadocs-openapi/server');
+  const { openapi } = await import('../../src/lib/openapi');
+  const { getDocOgPath } = await import('../../src/lib/site');
+
+  const docsSource = loader(
+    multiple({
+      docs: createSource({ metas: [], pages: [] }),
+      openapi: await openapiSource(openapi, {
+        baseDir: 'api-reference/api',
+        groupBy: 'tag',
+      }),
+    }),
+    {
+      baseUrl: '/',
+      plugins: [openapiPlugin()],
+    },
+  );
+
+  const lastModified = new Date().toISOString();
+
+  return docsSource
+    .getPages()
+    .filter((page) => page.data.type === 'openapi')
+    .map((page) => {
+      const title = page.data.title ?? 'API Reference';
+      const routePath =
+        page.url === '/' ? `${site.docsBasePath}/` : `${site.docsBasePath}${page.url}`;
+
+      return {
+        filePath: page.path,
+        ogOutputPath: `og/${page.slugs.join('/')}.png`,
+        routeSegments: page.slugs,
+        routePath,
+        ogImagePath: getDocOgPath(page.slugs),
+        title,
+        description: resolveSeoDescription({
+          title,
+          description: page.data.description,
+          slugs: page.slugs,
+          fallback: site.description,
+        }),
+        lastModified,
+      } satisfies DocEntry;
+    });
+}
+
 export async function getDocEntries(): Promise<DocEntry[]> {
   const files = await walk(docsDir);
   const docs = await Promise.all(
@@ -102,6 +151,8 @@ export async function getDocEntries(): Promise<DocEntry[]> {
         const parsed = matter(raw);
         const fileStat = await stat(filePath);
         const fallbackTitle = toTitleCase(routeSegments.at(-1) ?? site.name);
+        const title = typeof parsed.data.title === 'string' ? parsed.data.title : fallbackTitle;
+        const description = typeof parsed.data.description === 'string' ? parsed.data.description : undefined;
 
         return {
           filePath,
@@ -109,9 +160,14 @@ export async function getDocEntries(): Promise<DocEntry[]> {
           routeSegments,
           routePath,
           ogImagePath,
-          title: typeof parsed.data.title === 'string' ? parsed.data.title : fallbackTitle,
-          description:
-            typeof parsed.data.description === 'string' ? parsed.data.description : site.description,
+          title,
+          description: resolveSeoDescription({
+            title,
+            description,
+            ogDescription: frontmatterOgDescription(parsed.data as Record<string, unknown>),
+            slugs: routeSegments,
+            fallback: site.description,
+          }),
           lastModified: fileStat.mtime.toISOString(),
         } satisfies DocEntry;
       }),

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -3,10 +3,11 @@ import { dirname, resolve } from 'node:path';
 import { Resvg } from '@resvg/resvg-js';
 import { loader, multiple, source as createSource } from 'fumadocs-core/source';
 import { openapiPlugin, openapiSource } from 'fumadocs-openapi/server';
-import { getDocEntries, getDocSourceFiles } from './lib/content';
+import { getDocEntries, getDocSourceFiles, getOpenApiEntries } from './lib/content';
 import { getManifestKey } from '../src/lib/docs-manifest';
 import { openapi } from '../src/lib/openapi';
 import { preparePageTree } from '../src/lib/page-tree';
+import { resolveSeoDescription } from '../src/lib/seo';
 import { absoluteUrl, site } from './lib/site';
 import { getDocMarkdownPath, getDocOgPath } from '../src/lib/site';
 import { currentDirFromMetaUrl } from './lib/runtime-path';
@@ -108,8 +109,35 @@ function renderOgSvg(title: string, description: string, logoDataUri: string): s
   `.trim();
 }
 
+async function createDocsSource() {
+  const { metas, pages: sourcePages } = await getDocSourceFiles();
+
+  return loader(
+    multiple({
+      docs: createSource({ metas, pages: sourcePages }),
+      openapi: await openapiSource(openapi, {
+        baseDir: 'api-reference/api',
+        groupBy: 'tag',
+      }),
+    }),
+    {
+      baseUrl: '/',
+      plugins: [openapiPlugin()],
+    },
+  );
+}
+
+async function getSitemapEntries() {
+  const [docs, openapiDocs] = await Promise.all([getDocEntries(), getOpenApiEntries()]);
+  const seen = new Set(docs.map((doc) => doc.routePath.replace(/\/$/, '')));
+
+  return [...docs, ...openapiDocs.filter((doc) => !seen.has(doc.routePath.replace(/\/$/, '')))].sort(
+    (left, right) => left.routePath.localeCompare(right.routePath),
+  );
+}
+
 async function writeOgImages() {
-  const docs = await getDocEntries();
+  const docs = await getSitemapEntries();
   const outputRoot = resolve(currentDir, '../.output/public');
   const logoDataUri = await loadCoolifyLogoDataUri();
 
@@ -132,7 +160,7 @@ async function writeOgImages() {
 }
 
 async function writeSitemap() {
-  const docs = await getDocEntries();
+  const docs = await getSitemapEntries();
   const outputRoot = resolve(currentDir, '../.output/public');
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -165,28 +193,21 @@ Sitemap: ${absoluteUrl(`${site.docsBasePath}/sitemap.xml`)}
 
 async function writeDocsManifest() {
   const outputRoot = resolve(currentDir, '../.output/public');
-  const { metas, pages: sourcePages } = await getDocSourceFiles();
-  const docsSource = loader(
-    multiple({
-      docs: createSource({ metas, pages: sourcePages }),
-      openapi: await openapiSource(openapi, {
-        baseDir: 'api-reference/api',
-        groupBy: 'tag',
-      }),
-    }),
-    {
-      baseUrl: '/',
-      plugins: [openapiPlugin()],
-    },
-  );
+  const docsSource = await createDocsSource();
   const pageTree = await docsSource.serializePageTree(preparePageTree(docsSource.getPageTree()));
   const pages = Object.fromEntries(
     await Promise.all(docsSource.getPages().map(async (page) => {
+      const title = page.data.title ?? 'API Reference';
       const base = {
-        description: page.data.description ?? site.description,
+        description: resolveSeoDescription({
+          title,
+          description: page.data.description,
+          slugs: page.slugs,
+          fallback: site.description,
+        }),
         isIndex: page.slugs.length === 0,
         ogImagePath: getDocOgPath(page.slugs),
-        title: page.data.title,
+        title,
         url: page.url === '/' ? site.docsBasePath : `${site.docsBasePath}${page.url}`,
       };
 
@@ -224,9 +245,16 @@ async function copyBaseScopedPublicAssets() {
   const publicManifest = resolve(currentDir, '../public/site.webmanifest');
   const docsManifest = resolve(currentDir, '../.output/public/docs/site.webmanifest');
 
+  const publicNotFound = resolve(currentDir, '../public/404.html');
+  const docsNotFound = resolve(currentDir, '../.output/public/docs/404.html');
+  const rootNotFound = resolve(currentDir, '../.output/public/404.html');
+
   await cp(publicImages, docsImages, { recursive: true, force: true });
   await cp(publicBrand, docsBrand, { recursive: true, force: true });
   await cp(publicManifest, docsManifest, { force: true });
+  await mkdir(dirname(docsNotFound), { recursive: true });
+  await cp(publicNotFound, docsNotFound, { force: true });
+  await cp(publicNotFound, rootNotFound, { force: true });
 }
 
 async function cleanupNonStaticOutput() {

--- a/src/generated/services.json
+++ b/src/generated/services.json
@@ -169,6 +169,13 @@
     "category": "Development"
   },
   {
+    "name": "Buzz",
+    "slug": "buzz",
+    "icon": "/docs/images/services/buzz-logo.svg",
+    "description": "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.",
+    "category": "Messaging"
+  },
+  {
     "name": "Calcom",
     "slug": "calcom",
     "icon": "/docs/images/services/calcom-logo.svg",
@@ -285,8 +292,8 @@
     "name": "Cockpit",
     "slug": "cockpit",
     "icon": "/docs/images/services/cockpit-logo.svg",
-    "description": "Web-based server administration interface.",
-    "category": "Administration"
+    "description": "Headless CMS with REST & GraphQL APIs.",
+    "category": "CMS"
   },
   {
     "name": "Code Server",

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -19,7 +19,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       {
         type: 'main',
-        url: 'https://coolify.io/pricing/',
+        url: 'https://coolify.io/pricing',
         text: 'Coolify Cloud',
         external: true,
       },

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  frontmatterOgDescription,
+  isServiceDoc,
+  resolveSeoDescription,
+  serviceMetaDescription,
+  tocHasH1,
+} from './seo';
+
+describe('serviceMetaDescription', () => {
+  test('builds a one-click deploy template from the service name', () => {
+    expect(serviceMetaDescription('Ghost')).toBe(
+      'Deploy Ghost on Coolify with one-click Docker. Runs on your server with SSL and backups.',
+    );
+  });
+
+  test('keeps a short slogan and lengthens it', () => {
+    expect(serviceMetaDescription('WordPress', 'Website and blogging platform.')).toBe(
+      'Deploy WordPress on Coolify with one-click Docker. Website and blogging platform. Runs on your server with SSL and backups.',
+    );
+  });
+
+  test('keeps an already long description', () => {
+    const long =
+      'Deploy Ghost publishing platform on Coolify for professional blogs, newsletters, memberships, and content monetization with modern editor.';
+    expect(serviceMetaDescription('Ghost', long)).toBe(long);
+  });
+});
+
+describe('resolveSeoDescription', () => {
+  test('prefers a long Open Graph description for services', () => {
+    expect(
+      resolveSeoDescription({
+        title: 'WordPress',
+        description: 'Website and blogging platform.',
+        ogDescription:
+          'Run WordPress on Coolify for blogging, CMS, e-commerce with plugins, themes, and the most popular website building platform.',
+        slugs: ['services', 'wordpress'],
+        fallback: 'fallback',
+      }),
+    ).toContain('Run WordPress on Coolify');
+  });
+
+  test('does not rewrite non-service pages', () => {
+    expect(
+      resolveSeoDescription({
+        title: 'Installation',
+        description: 'Install Coolify self-hosted PaaS on Linux servers.',
+        slugs: ['get-started', 'installation'],
+        fallback: 'fallback',
+      }),
+    ).toBe('Install Coolify self-hosted PaaS on Linux servers.');
+  });
+
+  test('ignores service directory index pages', () => {
+    expect(isServiceDoc(['services', 'overview'])).toBe(false);
+    expect(isServiceDoc(['services', 'ghost'])).toBe(true);
+  });
+});
+
+describe('tocHasH1', () => {
+  test('detects a document H1 from the table of contents', () => {
+    expect(tocHasH1([{ depth: 2 }, { depth: 3 }])).toBe(false);
+    expect(tocHasH1([{ depth: 1 }, { depth: 2 }])).toBe(true);
+  });
+});
+
+describe('frontmatterOgDescription', () => {
+  test('reads nested og.description', () => {
+    expect(frontmatterOgDescription({ og: { description: 'Longer social description.' } })).toBe(
+      'Longer social description.',
+    );
+  });
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,67 @@
+const MIN_META_DESCRIPTION_LENGTH = 110;
+
+const serviceIndexSlugs = new Set(['all', 'overview', 'introduction', 'index']);
+
+export function isServiceDoc(slugs: string[]): boolean {
+  return slugs[0] === 'services' && slugs.length === 2 && !serviceIndexSlugs.has(slugs[1] ?? '');
+}
+
+export function serviceMetaDescription(name: string, description?: string): string {
+  const title = name.trim() || 'this service';
+  const slogan = (description ?? '').trim().replace(/\s+/g, ' ');
+  const suffix = 'Runs on your server with SSL and backups.';
+  const prefix = `Deploy ${title} on Coolify with one-click Docker.`;
+
+  if (!slogan) {
+    return `${prefix} ${suffix}`;
+  }
+
+  if (slogan.length >= MIN_META_DESCRIPTION_LENGTH) {
+    return slogan;
+  }
+
+  if (/^deploy\b/i.test(slogan)) {
+    return /ssl and backups/i.test(slogan) ? slogan : `${slogan.replace(/[.]+$/, '.')} ${suffix}`;
+  }
+
+  return `${prefix} ${slogan.replace(/[.]+$/, '.')} ${suffix}`;
+}
+
+export function resolveSeoDescription({
+  title,
+  description,
+  ogDescription,
+  slugs,
+  fallback,
+}: {
+  title: string;
+  description?: string;
+  ogDescription?: string;
+  slugs: string[];
+  fallback: string;
+}): string {
+  const og = ogDescription?.trim();
+  if (og && og.length >= MIN_META_DESCRIPTION_LENGTH) {
+    return og;
+  }
+
+  const text = description?.trim() ?? '';
+
+  if (isServiceDoc(slugs)) {
+    return serviceMetaDescription(title, text || og);
+  }
+
+  return text || og || fallback;
+}
+
+export function tocHasH1(toc: Array<{ depth: number }> | undefined | null): boolean {
+  return Boolean(toc?.some((item) => item.depth === 1));
+}
+
+export function frontmatterOgDescription(data: Record<string, unknown>): string | undefined {
+  const og = data.og;
+  if (!og || typeof og !== 'object') return undefined;
+
+  const description = (og as { description?: unknown }).description;
+  return typeof description === 'string' ? description : undefined;
+}

--- a/src/routes/$.tsx
+++ b/src/routes/$.tsx
@@ -7,12 +7,13 @@ import { Suspense, useLayoutEffect, type CSSProperties, type ReactNode } from 'r
 import { ClientAPIPage } from '@/components/api-page';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { useSidebar } from 'fumadocs-ui/layouts/docs/slots/sidebar';
-import { DocsBody, DocsPage, MarkdownCopyButton } from 'fumadocs-ui/layouts/docs/page';
+import { DocsBody, DocsPage, DocsTitle, MarkdownCopyButton } from 'fumadocs-ui/layouts/docs/page';
 import { useMDXComponents } from '@/components/mdx';
 import { ViewOptionsPopover } from '@/components/page-actions';
 import { type DocsManifest, getManifestKey, type LoaderData } from '@/lib/docs-manifest';
 import { baseOptions } from '@/lib/layout.shared';
 import { preparePageTree } from '@/lib/page-tree';
+import { resolveSeoDescription, tocHasH1 } from '@/lib/seo';
 import { absoluteUrl, getDocGithubPath, getDocOgPath, site } from '@/lib/site';
 import { getPageMarkdownUrl, source } from '@/lib/source';
 
@@ -30,11 +31,24 @@ function toPublicDocUrl(url: string): string {
 const folderIndexRedirects = new Map([
   ['applications/build-packs/overview', '/applications/build-packs'],
   ['applications/ci-cd/introduction', '/applications/ci-cd'],
+  ['applications/vitepress', '/applications/vite'],
+  ['api-reference/api', '/api-reference/authorization'],
+  ['cloud', '/get-started/cloud'],
+  ['cloud-vs-selfhost', '/get-started/usage'],
+  ['contact', '/get-started/support'],
+  ['downgrade', '/get-started/downgrade'],
+  ['installation', '/get-started/installation'],
   ['integrations/cloudflare/tunnels/overview', '/integrations/cloudflare/tunnels'],
   ['knowledge-base/overview', '/knowledge-base'],
-  ['knowledge-base/proxy/traefik/overview', '/knowledge-base/proxy/traefik'],
   ['knowledge-base/proxy/caddy/overview', '/knowledge-base/proxy/caddy'],
+  ['knowledge-base/proxy/traefik/overview', '/knowledge-base/proxy/traefik'],
+  ['screenshots', '/get-started/screenshots'],
+  ['support', '/get-started/support'],
   ['troubleshoot/overview', '/troubleshoot'],
+  ['uninstallation', '/get-started/uninstallation'],
+  ['upgrade', '/get-started/upgrade'],
+  ['videos', '/get-started/videos'],
+  ['what-is-coolify', '/get-started/introduction'],
 ]);
 
 export const Route = createFileRoute('/$')({
@@ -117,7 +131,12 @@ const serverLoader = createServerFn({
     if (page.data.type === 'openapi') {
       return {
         type: 'openapi',
-        description: page.data.description ?? site.description,
+        description: resolveSeoDescription({
+          title: page.data.title ?? 'API Reference',
+          description: page.data.description,
+          slugs: page.slugs,
+          fallback: site.description,
+        }),
         isIndex: page.slugs.length === 0,
         ogImagePath: getDocOgPath(page.slugs),
         pageTree,
@@ -129,7 +148,12 @@ const serverLoader = createServerFn({
 
     return {
       type: 'docs',
-      description: page.data.description ?? site.description,
+      description: resolveSeoDescription({
+        title: page.data.title,
+        description: page.data.description,
+        slugs: page.slugs,
+        fallback: site.description,
+      }),
       isIndex: page.slugs.length === 0,
       markdownUrl: getPageMarkdownUrl(page).url,
       ogImagePath: getDocOgPath(page.slugs),
@@ -185,6 +209,9 @@ const clientLoader = browserCollections.docs.createClientLoader({
       />
     );
 
+    const pageTitle = typeof frontmatter.title === 'string' ? frontmatter.title : undefined;
+    const heading = pageTitle && !tocHasH1(toc) ? <DocsTitle>{pageTitle}</DocsTitle> : null;
+
     if (frontmatter.full) {
       return (
         <DocsPage
@@ -195,6 +222,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
           footer={{ enabled: !hideFooter }}
         >
           <DocsBody>
+            {heading}
             <MDX components={useMDXComponents()} />
           </DocsBody>
         </DocsPage>
@@ -209,6 +237,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
         tableOfContentPopover={{ footer: pageActions }}
       >
         <DocsBody>
+          {heading}
           <MDX components={useMDXComponents()} />
         </DocsBody>
       </DocsPage>

--- a/src/routes/$.tsx
+++ b/src/routes/$.tsx
@@ -210,7 +210,8 @@ const clientLoader = browserCollections.docs.createClientLoader({
     );
 
     const pageTitle = typeof frontmatter.title === 'string' ? frontmatter.title : undefined;
-    const heading = pageTitle && !tocHasH1(toc) ? <DocsTitle>{pageTitle}</DocsTitle> : null;
+    const heading =
+      !frontmatter.full && pageTitle && !tocHasH1(toc) ? <DocsTitle>{pageTitle}</DocsTitle> : null;
 
     if (frontmatter.full) {
       return (
@@ -222,7 +223,6 @@ const clientLoader = browserCollections.docs.createClientLoader({
           footer={{ enabled: !hideFooter }}
         >
           <DocsBody>
-            {heading}
             <MDX components={useMDXComponents()} />
           </DocsBody>
         </DocsPage>
@@ -253,6 +253,7 @@ function Page() {
     content = (
       <DocsPage full tableOfContent={{ enabled: false }} breadcrumb={{ enabled: false }}>
         <DocsBody>
+          <DocsTitle>{data.title}</DocsTitle>
           <ClientAPIPage {...data.props} />
         </DocsBody>
       </DocsPage>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "strict": true,
     "baseUrl": ".",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,10 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import mdx from 'fumadocs-mdx/vite';
 import { nitro } from 'nitro/vite';
 import { defineConfig } from 'vite';
-import { getDocEntries } from './scripts/lib/content';
+import { getDocEntries, getOpenApiEntries } from './scripts/lib/content';
 import { siteDefinition } from './config/site.shared';
 
-const docEntries = await getDocEntries();
+const docEntries = [...(await getDocEntries()), ...(await getOpenApiEntries())];
 const prerenderDocPages = docEntries.map((doc) => ({
   path:
     doc.routeSegments.length === 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ahrefs Site Audit (project 6311765, crawl 2026-08-14) plus a live check on 2026-08-19. This PR stays in `coollabsio/coolify-docs` and only links to no-slash marketing URLs.

## Theme / layout / generation

- Header “Coolify Cloud” link is now `https://coolify.io/pricing` (no trailing slash). That is the sitewide chrome link Ahrefs saw on ~573 pages.
- Docs layout emits a single `<h1>` from frontmatter `title` when the MDX body has no `#` heading. This covers get-started pages and almost all service pages that start at `##`.
- OpenAPI endpoint pages also get an `<h1>` from their existing title. Live they currently start at `##` with an empty H1.
- The homepage is skipped because `CoolifyHome` already renders an H1.
- Service meta descriptions are expanded from existing frontmatter (`title`, `description`, or a long `og.description`) with a template like: `Deploy {name} on Coolify with one-click Docker. {slogan} Runs on your server with SSL and backups.` No 300-file service MDX grind. All 301 service pages now have metas ≥ 110 characters.
- Sitemap, OG images, and Vite prerender now include the `/docs/api-reference/api/*` endpoint pages that already exist in the nav and `llms.txt` (107 extra URLs on top of the ~466 MDX pages). No new API docs were invented.

## Nginx

- Leftover `/docs/installation/`, `/docs/upgrade/`, `/docs/contact/`, `/docs/cloud`, and the same paths without `/docs` now **301 to the specific get-started article**, including trailing-slash variants.
- Other known stale paths already 301’d correctly (`/docs/knowledge-base/overview`, `/api-reference/api`, `/applications/vitepress`); they stay as-is.
- Unknown docs paths no longer **302 to `/docs`**. Nginx now returns a real **404** (`public/404.html`). Trailing slashes on unknown `/docs/.../` URLs canonicalize with a 301 first.

## Content

- `/docs/get-started/usage` title: `Cloud vs Self-Hosted` (was `Usage` with an empty H1).
- `/docs/databases` title: `Databases` (was `Introduction`, colliding with get-started).
- Other `Introduction | Coolify Docs` collisions: Destinations, S3 Storage, Servers.
- Body links to `https://coolify.io/pricing/` updated to the no-slash URL.
- Removed leftover `vitepress` entry from the content-generation sidebar map.

`VITE_SITE_URL=https://coolify.io/docs/` is unchanged. That is a base URL, not a marketing href.

## Out of scope

- `coollabsio/coolify.io` marketing repo, including `/self-hosted`.
- Hand-editing hundreds of service MDX files.

## Verify

- `rg 'coolify.io/pricing/'` is empty.
- `bun test src/lib/seo.test.ts`
- `bun run types:check`
- Local content scan: 466 MDX + 107 OpenAPI sitemap entries; 0 service metas under 110 chars.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cedc969f-822c-434a-bcd0-f18afd11dc4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cedc969f-822c-434a-bcd0-f18afd11dc4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

